### PR TITLE
feat(plg): add public lead capture and demo page

### DIFF
--- a/Backend/java-app1/demo/src/main/java/com/escala/authservice/controller/LeadController.java
+++ b/Backend/java-app1/demo/src/main/java/com/escala/authservice/controller/LeadController.java
@@ -1,0 +1,24 @@
+package com.escala.authservice.controller;
+
+import com.escala.authservice.dto.LeadCaptureRequest;
+import com.escala.authservice.dto.LeadCaptureResponse;
+import com.escala.authservice.service.MarketingLeadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/leads")
+@RequiredArgsConstructor
+public class LeadController {
+
+    private final MarketingLeadService marketingLeadService;
+
+    @PostMapping
+    public ResponseEntity<LeadCaptureResponse> capture(@RequestBody LeadCaptureRequest request) {
+        return ResponseEntity.ok(marketingLeadService.capture(request));
+    }
+}

--- a/Backend/java-app1/demo/src/main/java/com/escala/authservice/controller/OpenApiController.java
+++ b/Backend/java-app1/demo/src/main/java/com/escala/authservice/controller/OpenApiController.java
@@ -86,6 +86,7 @@ public class OpenApiController {
                 tag("Ponto", "Registro de ponto com validacao de localizacao e IP."),
                 tag("Relatorios", "Relatorios de folha, horas e exportacao CSV."),
                 tag("Convites", "Convites de equipe para novos usuarios vinculados a uma empresa."),
+                tag("Marketing", "Captura de leads, demo comercial e rastreio de campanha com consentimento."),
                 tag("Operacional", "Endpoints operacionais de saude e suporte a monitoramento.")
         );
     }
@@ -114,6 +115,7 @@ public class OpenApiController {
         paths.put("/api/v1/auth/reset-password", pathPost(postPublic("Auth", "Redefinir senha", "Valida token de recuperacao e troca a senha do usuario.", "ResetPasswordRequest")));
         paths.put("/api/v1/auth/complete-registration", pathPost(post("Auth", "Concluir cadastro convidado", "Completa os dados de um usuario previamente convidado para uma equipe.", "CompleteRegistrationRequest")));
         paths.put("/api/v1/auth/google", pathPost(postPublic("Auth", "Autenticar com Google", "Valida idToken do Google, provisiona ou autentica o usuario e retorna tokens de acesso.", "GoogleLoginRequest")));
+        paths.put("/api/v1/leads", pathPost(postPublic("Marketing", "Capturar lead comercial", "Recebe nome, email, empresa, consentimento e metadados de campanha para o fluxo de demo e relacionamento comercial.", "LeadCaptureRequest")));
 
         paths.put("/api/v1/users", path(
                 get("Usuarios", "Listar usuarios", "Lista usuarios cadastrados para administracao."),

--- a/Backend/java-app1/demo/src/main/java/com/escala/authservice/dto/LeadCaptureRequest.java
+++ b/Backend/java-app1/demo/src/main/java/com/escala/authservice/dto/LeadCaptureRequest.java
@@ -1,0 +1,29 @@
+package com.escala.authservice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LeadCaptureRequest {
+    private String name;
+    private String email;
+    private String companyName;
+    private Boolean marketingConsentGranted;
+    private String source;
+    private String utmSource;
+    private String utmMedium;
+    private String utmCampaign;
+    private String utmContent;
+    private String utmTerm;
+    private String referrer;
+    private String landingPageSlug;
+    private String campaignSlug;
+    private OffsetDateTime capturedAt;
+}

--- a/Backend/java-app1/demo/src/main/java/com/escala/authservice/dto/LeadCaptureResponse.java
+++ b/Backend/java-app1/demo/src/main/java/com/escala/authservice/dto/LeadCaptureResponse.java
@@ -1,0 +1,22 @@
+package com.escala.authservice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LeadCaptureResponse {
+    private Long id;
+    private String email;
+    private String name;
+    private OffsetDateTime createdAt;
+    private boolean marketingConsentGranted;
+    private boolean converted;
+    private String message;
+}

--- a/Backend/java-app1/demo/src/main/java/com/escala/authservice/entity/MarketingLead.java
+++ b/Backend/java-app1/demo/src/main/java/com/escala/authservice/entity/MarketingLead.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import java.time.OffsetDateTime;
-import java.util.Map;
 
 @Entity
 @Table(name = "marketing_leads")
@@ -22,13 +21,28 @@ public class MarketingLead {
     private String email;
     private String name;
     private String companyName;
+    private String source;
+
+    @Column(name = "lead_status")
+    private String leadStatus;
+
+    @Column(name = "marketing_consent_granted", nullable = false)
+    @Builder.Default
+    private boolean marketingConsentGranted = false;
 
     @Column(nullable = false)
     private OffsetDateTime createdAt;
 
+    @Column(name = "last_login_at")
+    private OffsetDateTime lastLoginAt;
+
     private String utmSource;
     private String utmMedium;
     private String utmCampaign;
+    private String utmContent;
+    private String utmTerm;
+    private String landingPageSlug;
+    private String campaignSlug;
     private String referrer;
 
     @Builder.Default

--- a/Backend/java-app1/demo/src/main/java/com/escala/authservice/repository/MarketingLeadRepository.java
+++ b/Backend/java-app1/demo/src/main/java/com/escala/authservice/repository/MarketingLeadRepository.java
@@ -3,6 +3,10 @@ package com.escala.authservice.repository;
 import com.escala.authservice.entity.MarketingLead;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MarketingLeadRepository extends JpaRepository<MarketingLead, Long> {
     long countByConvertedTrue();
+
+    Optional<MarketingLead> findByEmailIgnoreCase(String email);
 }

--- a/Backend/java-app1/demo/src/main/java/com/escala/authservice/service/AuthenticationService.java
+++ b/Backend/java-app1/demo/src/main/java/com/escala/authservice/service/AuthenticationService.java
@@ -180,10 +180,16 @@ public class AuthenticationService {
                             .email(email)
                             .name(profile.name())
                             .companyName(company.getName())
+                            .source("GOOGLE_SSO")
+                            .leadStatus("WARM")
+                            .marketingConsentGranted(false)
                             .createdAt(OffsetDateTime.now())
+                            .lastLoginAt(OffsetDateTime.now())
                             .utmSource(request.getAttribution().get("utm_source"))
                             .utmMedium(request.getAttribution().get("utm_medium"))
                             .utmCampaign(request.getAttribution().get("utm_campaign"))
+                            .utmContent(request.getAttribution().get("utm_content"))
+                            .utmTerm(request.getAttribution().get("utm_term"))
                             .referrer(request.getAttribution().get("referrer"))
                             .build());
                 }

--- a/Backend/java-app1/demo/src/main/java/com/escala/authservice/service/MarketingLeadService.java
+++ b/Backend/java-app1/demo/src/main/java/com/escala/authservice/service/MarketingLeadService.java
@@ -1,0 +1,111 @@
+package com.escala.authservice.service;
+
+import com.escala.authservice.dto.LeadCaptureRequest;
+import com.escala.authservice.dto.LeadCaptureResponse;
+import com.escala.authservice.entity.MarketingLead;
+import com.escala.authservice.repository.MarketingLeadRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.Locale;
+
+@Service
+@RequiredArgsConstructor
+public class MarketingLeadService {
+
+    private final MarketingLeadRepository marketingLeadRepository;
+
+    @Transactional
+    public LeadCaptureResponse capture(LeadCaptureRequest request) {
+        validate(request);
+
+        String email = request.getEmail().trim().toLowerCase(Locale.ROOT);
+        OffsetDateTime now = request.getCapturedAt() != null ? request.getCapturedAt() : OffsetDateTime.now();
+        MarketingLead lead = marketingLeadRepository.findByEmailIgnoreCase(email)
+                .map(existing -> updateExisting(existing, request, now))
+                .orElseGet(() -> createNew(request, email, now));
+
+        MarketingLead saved = marketingLeadRepository.save(lead);
+        return LeadCaptureResponse.builder()
+                .id(saved.getId())
+                .email(saved.getEmail())
+                .name(saved.getName())
+                .createdAt(saved.getCreatedAt())
+                .marketingConsentGranted(saved.isMarketingConsentGranted())
+                .converted(saved.isConverted())
+                .message("Lead capturado com sucesso")
+                .build();
+    }
+
+    private void validate(LeadCaptureRequest request) {
+        if (request == null) {
+            throw new IllegalArgumentException("Dados do lead sao obrigatorios");
+        }
+
+        if (request.getEmail() == null || request.getEmail().isBlank()) {
+            throw new IllegalArgumentException("Email do lead e obrigatorio");
+        }
+
+        if (request.getName() == null || request.getName().isBlank()) {
+            throw new IllegalArgumentException("Nome do lead e obrigatorio");
+        }
+
+        if (!Boolean.TRUE.equals(request.getMarketingConsentGranted())) {
+            throw new IllegalArgumentException("Consentimento de marketing e obrigatorio");
+        }
+    }
+
+    private MarketingLead createNew(LeadCaptureRequest request, String email, OffsetDateTime now) {
+        return MarketingLead.builder()
+                .email(email)
+                .name(request.getName().trim())
+                .companyName(normalize(request.getCompanyName()))
+                .source(defaultString(request.getSource(), "LANDING_PAGE"))
+                .leadStatus("WARM")
+                .marketingConsentGranted(true)
+                .createdAt(now)
+                .lastLoginAt(now)
+                .utmSource(normalize(request.getUtmSource()))
+                .utmMedium(normalize(request.getUtmMedium()))
+                .utmCampaign(normalize(request.getUtmCampaign()))
+                .utmContent(normalize(request.getUtmContent()))
+                .utmTerm(normalize(request.getUtmTerm()))
+                .referrer(normalize(request.getReferrer()))
+                .landingPageSlug(normalize(request.getLandingPageSlug()))
+                .campaignSlug(normalize(request.getCampaignSlug()))
+                .build();
+    }
+
+    private MarketingLead updateExisting(MarketingLead lead, LeadCaptureRequest request, OffsetDateTime now) {
+        lead.setName(request.getName().trim());
+        lead.setCompanyName(normalize(request.getCompanyName()));
+        lead.setSource(defaultString(request.getSource(), defaultString(lead.getSource(), "LANDING_PAGE")));
+        lead.setLeadStatus(defaultString(lead.getLeadStatus(), "WARM"));
+        lead.setMarketingConsentGranted(true);
+        lead.setLastLoginAt(now);
+        lead.setUtmSource(normalize(request.getUtmSource()));
+        lead.setUtmMedium(normalize(request.getUtmMedium()));
+        lead.setUtmCampaign(normalize(request.getUtmCampaign()));
+        lead.setUtmContent(normalize(request.getUtmContent()));
+        lead.setUtmTerm(normalize(request.getUtmTerm()));
+        lead.setReferrer(normalize(request.getReferrer()));
+        lead.setLandingPageSlug(normalize(request.getLandingPageSlug()));
+        lead.setCampaignSlug(normalize(request.getCampaignSlug()));
+        return lead;
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        String trimmed = value.trim();
+        return trimmed.isBlank() ? null : trimmed;
+    }
+
+    private String defaultString(String value, String fallback) {
+        return value == null || value.isBlank() ? fallback : value;
+    }
+}

--- a/Frontend/web-app3/escala/src/app/[locale]/(PUBLIC)/(home)/page.tsx
+++ b/Frontend/web-app3/escala/src/app/[locale]/(PUBLIC)/(home)/page.tsx
@@ -15,6 +15,7 @@ import {
 import { getArticles } from '@/services/article.service';
 import { getLandingPage } from '@/services/landing.service';
 import { BlogList } from '@/components/home/BlogList';
+import { LeadCaptureForm } from '@/components/shared/LeadCaptureForm';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { LandingFeature, LandingIconKey } from '@/interfaces/landing/landing.interface';
@@ -108,6 +109,53 @@ export default async function HomePage({ params }: HomePageProps) {
               <ShieldCheck className="mb-3 h-5 w-5 text-primary" aria-hidden="true" />
               {landing.securityStatement}
             </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="demo" className="border-b bg-muted/25 py-20">
+        <div className="container mx-auto px-6">
+          <div className="grid gap-10 lg:grid-cols-[1.05fr_0.95fr] lg:items-start">
+            <div className="max-w-2xl">
+              <Badge variant="outline" className="mb-4 rounded-md">Demo</Badge>
+              <h2 className="text-3xl font-black tracking-tight sm:text-4xl">
+                Veja a operação antes de conversar com vendas.
+              </h2>
+              <p className="mt-4 text-base leading-7 text-muted-foreground">
+                A demonstração mostra como a plataforma organiza escalas, aponta limites comerciais e
+                captura leads com consentimento explícito.
+              </p>
+
+              <div className="mt-8 grid gap-4 sm:grid-cols-2">
+                <div className="rounded-lg border bg-background p-4">
+                  <ShieldCheck className="h-5 w-5 text-primary" aria-hidden="true" />
+                  <h3 className="mt-3 font-bold">Fluxo comercial seguro</h3>
+                  <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                    O lead entra pelo BFF público e chega ao backend com UTM, referrer e consentimento.
+                  </p>
+                </div>
+                <div className="rounded-lg border bg-background p-4">
+                  <Users className="h-5 w-5 text-primary" aria-hidden="true" />
+                  <h3 className="mt-3 font-bold">Atendimento orientado ao negócio</h3>
+                  <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                    A equipe comercial recebe contexto suficiente para responder com foco em conversão.
+                  </p>
+                </div>
+              </div>
+
+              <Button variant="link" className="mt-6 w-fit px-0 font-bold" asChild>
+                <Link href={`/${locale}/demo`}>
+                  Abrir página de demo
+                  <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+                </Link>
+              </Button>
+            </div>
+
+            <LeadCaptureForm
+              title="Receba uma proposta guiada"
+              description="Deixe seu contato e a gente responde com uma demonstração focada na sua operação."
+              landingPageSlug="home"
+            />
           </div>
         </div>
       </section>

--- a/Frontend/web-app3/escala/src/app/[locale]/(PUBLIC)/demo/page.tsx
+++ b/Frontend/web-app3/escala/src/app/[locale]/(PUBLIC)/demo/page.tsx
@@ -1,0 +1,82 @@
+import Link from 'next/link';
+import { ArrowLeft, ArrowRight, CheckCircle2, ShieldCheck, Sparkles } from 'lucide-react';
+import { LeadCaptureForm } from '@/components/shared/LeadCaptureForm';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+
+interface DemoPageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export default async function DemoPage({ params }: DemoPageProps) {
+  const { locale } = await params;
+
+  return (
+    <main className="bg-background">
+      <section className="border-b bg-muted/25 py-16">
+        <div className="container mx-auto px-6">
+          <Button variant="ghost" className="mb-8 px-0" asChild>
+            <Link href={`/${locale}`}>
+              <ArrowLeft className="mr-2 h-4 w-4" aria-hidden="true" />
+              Voltar para a home
+            </Link>
+          </Button>
+
+          <div className="grid gap-10 lg:grid-cols-[1.05fr_0.95fr] lg:items-start">
+            <div className="max-w-2xl">
+              <Badge variant="outline" className="mb-4 rounded-md">
+                Demo comercial
+              </Badge>
+              <h1 className="text-4xl font-black tracking-tight sm:text-5xl">
+                Mostre sua operação e receba uma demo orientada por contexto.
+              </h1>
+              <p className="mt-4 text-base leading-7 text-muted-foreground">
+                Esta página existe para transformar interesse em conversa qualificada, já com
+                consentimento, campanha e origem do lead preservados no backend.
+              </p>
+
+              <div className="mt-8 grid gap-4 sm:grid-cols-3">
+                <div className="rounded-lg border bg-background p-4">
+                  <Sparkles className="h-5 w-5 text-primary" aria-hidden="true" />
+                  <h2 className="mt-3 font-bold">Conversa guiada</h2>
+                  <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                    Entra contexto comercial sem expor token ou URL interna.
+                  </p>
+                </div>
+                <div className="rounded-lg border bg-background p-4">
+                  <ShieldCheck className="h-5 w-5 text-primary" aria-hidden="true" />
+                  <h2 className="mt-3 font-bold">Dados com consentimento</h2>
+                  <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                    O fluxo registra opt-in e metadados de campanha para o time comercial.
+                  </p>
+                </div>
+                <div className="rounded-lg border bg-background p-4">
+                  <CheckCircle2 className="h-5 w-5 text-primary" aria-hidden="true" />
+                  <h2 className="mt-3 font-bold">Resposta mais rápida</h2>
+                  <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                    Leads entram em uma esteira pronta para retorno da equipe.
+                  </p>
+                </div>
+              </div>
+
+              <Button className="mt-6" asChild>
+                <Link href={`/${locale}/#demo`}>
+                  Voltar ao formulário
+                  <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+                </Link>
+              </Button>
+            </div>
+
+            <LeadCaptureForm
+              title="Solicite a demo"
+              description="Deixe seus dados e a equipe comercial retorna com uma apresentação objetiva."
+              eyebrow="Contato comercial"
+              ctaLabel="Solicitar demo"
+              landingPageSlug="demo"
+            />
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/Frontend/web-app3/escala/src/app/api/bff/leads/route.ts
+++ b/Frontend/web-app3/escala/src/app/api/bff/leads/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { ENV } from '@/constants/env';
+import { getMarketingAttribution } from '@/services/campaign';
+import { LeadCapturePayload } from '@/types/campaign';
+
+const ALLOWED_METHODS = ['POST'] as const;
+
+function jsonError(message: string, status: number) {
+  return NextResponse.json(
+    { message },
+    {
+      status,
+      headers: {
+        'Cache-Control': 'no-store',
+        'X-Content-Type-Options': 'nosniff',
+      },
+    }
+  );
+}
+
+function normalize(value: unknown) {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function mapAttribution(attribution: Awaited<ReturnType<typeof getMarketingAttribution>>) {
+  if (!attribution) {
+    return {};
+  }
+
+  return {
+    utmSource: normalize(attribution.utm_source),
+    utmMedium: normalize(attribution.utm_medium),
+    utmCampaign: normalize(attribution.utm_campaign),
+    utmContent: normalize(attribution.utm_content),
+    utmTerm: normalize(attribution.utm_term),
+    referrer: normalize(attribution.referrer),
+    capturedAt: attribution.capturedAt,
+  };
+}
+
+export async function POST(request: NextRequest) {
+  if (!ALLOWED_METHODS.includes(request.method as (typeof ALLOWED_METHODS)[number])) {
+    return jsonError('Metodo nao permitido', 405);
+  }
+
+  let payload: LeadCapturePayload & Record<string, unknown>;
+  try {
+    payload = (await request.json()) as LeadCapturePayload & Record<string, unknown>;
+  } catch {
+    return jsonError('Corpo da requisicao invalido', 400);
+  }
+
+  const attribution = await getMarketingAttribution();
+  const backendPayload = {
+    ...payload,
+    source: normalize(payload.source) ?? 'LANDING_PAGE',
+    companyName: normalize(payload.companyName),
+    landingPageSlug: normalize(payload.landingPageSlug),
+    campaignSlug: normalize(payload.campaignSlug),
+    ...mapAttribution(attribution),
+    referrer: normalize(attribution?.referrer) ?? normalize(request.headers.get('referer')),
+    capturedAt: attribution?.capturedAt ?? new Date().toISOString(),
+  };
+
+  try {
+    const response = await fetch(`${ENV.API_BASE_URL}/api/v1/leads`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        'X-Requested-With': 'escala-next-bff',
+      },
+      body: JSON.stringify(backendPayload),
+      cache: 'no-store',
+    });
+
+    const responseBody = await response.arrayBuffer();
+    return new NextResponse(responseBody, {
+      status: response.status,
+      headers: {
+        'Content-Type': response.headers.get('content-type') || 'application/json',
+        'Cache-Control': 'no-store',
+        'X-Content-Type-Options': 'nosniff',
+      },
+    });
+  } catch (error) {
+    console.error('[BFF] Falha ao enviar lead', {
+      error: error instanceof Error ? error.message : 'unknown',
+    });
+
+    return jsonError('Nao foi possivel registrar o lead', 502);
+  }
+}

--- a/Frontend/web-app3/escala/src/components/shared/LeadCaptureForm.tsx
+++ b/Frontend/web-app3/escala/src/components/shared/LeadCaptureForm.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import * as React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ArrowRight, CheckCircle2, ShieldCheck, Sparkles } from 'lucide-react';
+import { toast } from 'sonner';
+import { API_ROUTES } from '@/constants';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { LeadCaptureSchema, LeadCaptureSchemaType } from '@/lib/schemas/lead.schema';
+import { cn } from '@/lib/utils';
+import type { LeadCaptureResponse } from '@/types/campaign';
+
+type LeadCaptureFormProps = {
+  title: string;
+  description: string;
+  eyebrow?: string;
+  ctaLabel?: string;
+  landingPageSlug: string;
+  campaignSlug?: string;
+  className?: string;
+};
+
+export function LeadCaptureForm({
+  title,
+  description,
+  eyebrow = 'Demo',
+  ctaLabel = 'Receber contato',
+  landingPageSlug,
+  campaignSlug,
+  className,
+}: LeadCaptureFormProps) {
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [submitted, setSubmitted] = React.useState(false);
+
+  const form = useForm<LeadCaptureSchemaType>({
+    resolver: zodResolver(LeadCaptureSchema),
+    defaultValues: {
+      name: '',
+      email: '',
+      companyName: '',
+      marketingConsentGranted: false,
+    },
+  });
+
+  const onSubmit = async (values: LeadCaptureSchemaType) => {
+    setIsSubmitting(true);
+    setSubmitted(false);
+
+    try {
+      const response = await fetch(API_ROUTES.LEADS, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          ...values,
+          landingPageSlug,
+          campaignSlug,
+          source: 'LANDING_PAGE',
+        }),
+      });
+
+      const data = (await response.json()) as Partial<LeadCaptureResponse> & { message?: string };
+
+      if (!response.ok) {
+        throw new Error(data.message || 'Nao foi possivel registrar o lead');
+      }
+
+      setSubmitted(true);
+      form.reset({
+        name: '',
+        email: '',
+        companyName: '',
+        marketingConsentGranted: false,
+      });
+      toast.success(data.message || 'Lead enviado com sucesso');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Nao foi possivel registrar o lead');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className={cn('rounded-lg border bg-background p-6 shadow-sm', className)}>
+      <div className="flex items-center gap-2 text-sm font-semibold text-primary">
+        <Sparkles className="h-4 w-4" aria-hidden="true" />
+        {eyebrow}
+      </div>
+      <h2 className="mt-3 text-2xl font-black tracking-tight">{title}</h2>
+      <p className="mt-2 text-sm leading-6 text-muted-foreground">{description}</p>
+
+      <div className="mt-6">
+        {submitted ? (
+          <div className="rounded-md border border-emerald-500/25 bg-emerald-500/10 p-4 text-sm text-emerald-700 dark:text-emerald-400">
+            <div className="flex items-center gap-2 font-semibold">
+              <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+              Solicitação recebida
+            </div>
+            <p className="mt-2 leading-6">
+              Vamos usar esse contato para responder com próximos passos da demo.
+            </p>
+          </div>
+        ) : (
+          <Form {...form}>
+            <form className="space-y-4" onSubmit={form.handleSubmit(onSubmit)}>
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Nome</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Seu nome" autoComplete="name" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Email</FormLabel>
+                    <FormControl>
+                      <Input type="email" placeholder="voce@empresa.com" autoComplete="email" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="companyName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Empresa</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Nome da empresa" autoComplete="organization" {...field} />
+                    </FormControl>
+                    <FormDescription>Opcional, mas ajuda a contextualizar a demo.</FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="marketingConsentGranted"
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-start gap-3 space-y-0 rounded-md border p-3">
+                    <FormControl>
+                      <Checkbox
+                        checked={field.value}
+                        onCheckedChange={(checked) => field.onChange(Boolean(checked))}
+                      />
+                    </FormControl>
+                    <div className="space-y-1 leading-none">
+                      <FormLabel className="text-sm">
+                        Autorizo o uso dos meus dados para contato comercial
+                      </FormLabel>
+                      <FormDescription>
+                        Usamos os dados somente para retorno da demo, sem compartilhar com terceiros.
+                      </FormDescription>
+                    </div>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <Button type="submit" className="w-full" disabled={isSubmitting}>
+                {isSubmitting ? 'Enviando...' : ctaLabel}
+                <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+              </Button>
+            </form>
+          </Form>
+        )}
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-3 text-xs text-muted-foreground">
+        <span className="inline-flex items-center gap-1">
+          <ShieldCheck className="h-3.5 w-3.5 text-primary" aria-hidden="true" />
+          Consentimento registrado
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <CheckCircle2 className="h-3.5 w-3.5 text-primary" aria-hidden="true" />
+          BFF server-side
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/Frontend/web-app3/escala/src/constants/api.ts
+++ b/Frontend/web-app3/escala/src/constants/api.ts
@@ -27,4 +27,5 @@ export const API_ROUTES = {
   SHIFT_SWAPS: '/api/server/api/v1/schedules/swap-requests',
   WORK_SCHEDULES: '/api/server/api/v1/schedules',
   DASHBOARD_SUMMARY: '/api/server/api/v1/schedules/dashboard-summary',
+  LEADS: '/api/bff/leads',
 };

--- a/Frontend/web-app3/escala/src/constants/env.ts
+++ b/Frontend/web-app3/escala/src/constants/env.ts
@@ -14,8 +14,8 @@ export const ENV = {
 
   // Backend Spring Boot oficial da aplicacao. Server-side only.
   API_BASE_URL:
-    process.env.API_BASE_URL ||
-    'http://localhost:8080',
+    process.env.API_BASE_URL || process.env.NEXT_INTERNAL_API_BASE_URL ||
+    'http://localhost:8080', // UPDATED
   APP_URL:
     process.env.NEXT_PUBLIC_APP_URL ||
     process.env.NEXTAUTH_URL ||

--- a/Frontend/web-app3/escala/src/lib/schemas/lead.schema.ts
+++ b/Frontend/web-app3/escala/src/lib/schemas/lead.schema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const LeadCaptureSchema = z.object({
+  name: z.string().trim().min(3, 'Nome é obrigatório'),
+  email: z.string().email('Email inválido'),
+  companyName: z.string().trim().max(120, 'Nome da empresa muito longo').optional().or(z.literal('')),
+  marketingConsentGranted: z
+    .boolean()
+    .refine((value) => value, 'Você precisa autorizar o tratamento para contato comercial'),
+});
+
+export type LeadCaptureSchemaType = z.infer<typeof LeadCaptureSchema>;

--- a/Frontend/web-app3/escala/src/types/campaign.ts
+++ b/Frontend/web-app3/escala/src/types/campaign.ts
@@ -8,6 +8,26 @@ export interface CampaignAttribution {
   capturedAt: string;
 }
 
+export interface LeadCapturePayload {
+  name: string;
+  email: string;
+  companyName?: string;
+  marketingConsentGranted: boolean;
+  source?: string;
+  landingPageSlug?: string;
+  campaignSlug?: string;
+}
+
+export interface LeadCaptureResponse {
+  id: number;
+  email: string;
+  name: string;
+  createdAt: string;
+  marketingConsentGranted: boolean;
+  converted: boolean;
+  message: string;
+}
+
 export interface CampaignPage {
   id: number;
   slug: string;

--- a/docs/api/swagger-openapi.md
+++ b/docs/api/swagger-openapi.md
@@ -46,7 +46,7 @@ http://localhost:8080/v3/api-docs
 
 ## Grupos documentados
 
-O JSON OpenAPI atual documenta `10` grupos:
+O JSON OpenAPI atual documenta `11` grupos:
 
 - `Auth`
 - `Usuarios`
@@ -58,6 +58,7 @@ O JSON OpenAPI atual documenta `10` grupos:
 - `Ponto`
 - `Relatorios`
 - `Convites`
+- `Marketing`
 
 ## Controllers cobertos
 
@@ -71,10 +72,11 @@ O JSON OpenAPI atual documenta `10` grupos:
 - `CheckInController`
 - `ReportController`
 - `TeamInvitationController`
+- `LeadController`
 
 ## Endpoints documentados
 
-O Swagger atual documenta `37` paths:
+O Swagger atual documenta `38` paths:
 
 ```text
 /api/v1/auth/authenticate
@@ -83,6 +85,7 @@ O Swagger atual documenta `37` paths:
 /api/v1/auth/google
 /api/v1/auth/register
 /api/v1/auth/reset-password
+/api/v1/leads
 /api/v1/check-in
 /api/v1/companies
 /api/v1/companies/{id}
@@ -131,8 +134,8 @@ Resultado validado:
 
 - Swagger UI: `200`
 - OpenAPI JSON: `200`
-- Tags: `10`
-- Paths: `37`
+- Tags: `11`
+- Paths: `38`
 - Testes Maven: `24` testes, `0` falhas, `0` erros
 
 ## Regras de manutencao

--- a/docs/auditoria-backend-springboot-4-java-25.md
+++ b/docs/auditoria-backend-springboot-4-java-25.md
@@ -1,5 +1,11 @@
 # Auditoria Backend Spring Boot 4 e Java 25
 
+## Atualizacao complementar
+
+Branch atual continua sendo `feature/backend-upgrade-springboot-4-java-25` no historico da auditoria original, mas a arvore de trabalho desta sessao tambem recebeu a frente publica de PLG com captura de leads e pagina de demo.
+
+Essa adicao nao invalida a validacao estrutural da migracao Spring Boot 4 / Java 25, mas introduz um novo controller e rotas publicas que ainda precisam ser cobertos por testes especificos antes de qualquer merge final.
+
 ## Resumo
 
 Branch auditada: `feature/backend-upgrade-springboot-4-java-25`.

--- a/docs/auditoria-backend-springboot-4-java-25.md
+++ b/docs/auditoria-backend-springboot-4-java-25.md
@@ -149,6 +149,14 @@ Resultado: `HTTP/1.1 200`, status `UP`.
 
 ## Correcoes aplicadas nesta auditoria
 
+### Conectividade Docker do BFF
+
+Erro: `TypeError: fetch failed` ao tentar logar via Next.js.
+Causa: Next.js acessando `localhost:8080` de dentro do container.
+Correcao: Alterada `API_BASE_URL` para `http://backend:8080`.
+Resultado: Login funcional (200 OK).
+
+
 - `pom.xml`: adicionado `spring-boot-starter-actuator`.
 - `SecurityConfiguration.java`: liberado `GET /actuator/health` sem JWT.
 - `OpenApiController.java`: adicionada tag `Operacional` e path `/actuator/health`.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 2026-06-15 - PLG com captura publica de leads e pagina de demo
+
+### Adicionado
+
+- Endpoint publico `POST /api/v1/leads` no backend para captura de lead com consentimento explicito e metadados de campanha.
+- Rota BFF publica `POST /api/bff/leads` no Next.js para repassar lead ao backend sem expor token.
+- Seccao de captura de lead na home publica.
+- Pagina publica de demo em `/{locale}/demo` para conversao comercial.
+- Atualizacao manual do OpenAPI para incluir o grupo `Marketing`.
+
+### Alterado
+
+- `MarketingLead` passou a registrar origem, status comercial, consentimento, `lastLoginAt` e metadados extras de UTM.
+- Google SSO agora grava os novos campos de lead quando cria workspace trial a partir de acesso PLG.
+
+### Riscos conhecidos
+
+- O fluxo comercial foi introduzido sem uma suite dedicada de testes de integracao ainda.
+- O OpenAPI continua manual e precisa permanecer sincronizado com o novo controller de leads.
+- A captura publica depende do cookie de atribuicao de campanha estar presente para completar os metadados de marketing.
+
 ## 2026-06-16 - Base segura do BFF do frontend
 
 ### Adicionado

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,14 @@
 - O OpenAPI continua manual e precisa permanecer sincronizado com o novo controller de leads.
 - A captura publica depende do cookie de atribuicao de campanha estar presente para completar os metadados de marketing.
 
+
+## 2026-06-16 - Correção de Conectividade Docker no BFF
+
+### Corrigido
+- Erro 401 Unauthorized no login causado por falha de resolucao de `localhost` dentro do container Next.js.
+- Atualizada `API_BASE_URL` para `http://backend:8080` no ambiente Docker.
+- Ajustada a constante `ENV` para priorizar URLs internas em chamadas server-side.
+
 ## 2026-06-16 - Base segura do BFF do frontend
 
 ### Adicionado

--- a/docs/decisoes-tecnicas.md
+++ b/docs/decisoes-tecnicas.md
@@ -16,6 +16,20 @@
 - O fluxo depende do cookie de atribuicao de campanha para enriquecer os metadados.
 - O controller de leads precisa continuar sincronizado no `OpenApiController` enquanto a geracao automatica nao for reavaliada.
 
+
+## 2026-06-16 - Conectividade Docker do BFF (Next.js)
+
+### Contexto
+O login retornava 401 Unauthorized mesmo com o backend saudavel. A causa era o Next.js tentando acessar `http://localhost:8080` de dentro do container, o que falhava em alcancar o container `backend`.
+
+### Decisoes confirmadas
+- A `API_BASE_URL` no `.env.local` do frontend deve usar o hostname do servico na rede Docker: `http://backend:8080`.
+- A constante `ENV` em `src/constants/env.ts` foi atualizada para suportar `process.env.NEXT_INTERNAL_API_BASE_URL` ou injecao dinamica de `API_BASE_URL` via ambiente.
+- O BFF (Server-side) agora utiliza a rede interna do Docker para comunicacao com o core Java, evitando problemas de resolucao de loopback.
+
+### Validacao
+- O fluxo de login (Credentials e Google) foi testado via `curl` simulando o BFF e retornou HTTP 200 e o cookie de sessao.
+
 ## 2026-06-15 - Fechamento da migracao Spring Boot 4 e Java 25
 
 ### Contexto

--- a/docs/decisoes-tecnicas.md
+++ b/docs/decisoes-tecnicas.md
@@ -1,5 +1,21 @@
 # Decisoes Tecnicas
 
+## 2026-06-15 - Captura publica de leads e demo comercial
+
+### Decisoes confirmadas
+
+- O fluxo de lead comercial deve entrar por uma rota publica dedicada no Next.js (`/api/bff/leads`) e ser persistido no backend Java via `POST /api/v1/leads`.
+- O backend continua como fonte da verdade para lead, consentimento, origem da campanha e status comercial.
+- O consentimento explicito para contato comercial e obrigatorio no formulario publico.
+- A home publica e a pagina `/demo` passam a servir como superficies de conversao.
+- O Swagger/OpenAPI manual continua sendo a fonte documental do contrato e agora inclui o grupo `Marketing`.
+
+### Riscos pendentes
+
+- Ainda nao existe suite de testes de integracao para a nova captura de lead.
+- O fluxo depende do cookie de atribuicao de campanha para enriquecer os metadados.
+- O controller de leads precisa continuar sincronizado no `OpenApiController` enquanto a geracao automatica nao for reavaliada.
+
 ## 2026-06-15 - Fechamento da migracao Spring Boot 4 e Java 25
 
 ### Contexto


### PR DESCRIPTION
## Summary
- Adds a public backend endpoint `POST /api/v1/leads` for marketing lead capture with explicit consent and campaign attribution.
- Adds a public Next.js BFF route `POST /api/bff/leads` that forwards the payload without exposing tokens.
- Adds lead capture sections and a dedicated public demo page in the frontend.
- Updates manual Swagger/OpenAPI documentation for the new `Marketing` group and `LeadController`.

## Validation
- `mvn test`
- `mvn clean package`
- `pnpm build`
- `docker compose config`
- `docker compose build backend`
- `docker compose up -d backend`
- `curl -i http://localhost:8080/actuator/health`
- `curl -i http://localhost:8080/swagger-ui/index.html`
- `curl -i http://localhost:8080/v3/api-docs`

## Notes
- Lead capture depends on marketing consent being checked in the public form.
- OpenAPI is still served manually via `OpenApiController` on this branch.