### PR TITLE
[P0][Security] Audit BFF NextAuth Spring authentication

### DIFF
--- a/Backend/java-app1/demo/src/main/java/com/escala/authservice/config/SecurityConfiguration.java
+++ b/Backend/java-app1/demo/src/main/java/com/escala/authservice/config/SecurityConfiguration.java
@@ -118,7 +118,9 @@ public class SecurityConfiguration {
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "If-Match", "X-Requested-With"));
         configuration.setExposedHeaders(List.of("ETag"));
-        configuration.setAllowCredentials(true);
+        // Spring receives only Authorization: Bearer from the BFF, never a
+        // browser session cookie. CORS credentials would add CSRF surface.
+        configuration.setAllowCredentials(false);
         configuration.setMaxAge(3600L);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/Backend/java-app1/demo/src/main/java/com/escala/authservice/controller/OpenApiController.java
+++ b/Backend/java-app1/demo/src/main/java/com/escala/authservice/controller/OpenApiController.java
@@ -141,7 +141,7 @@ public class OpenApiController {
         Map<String, Object> paths = new LinkedHashMap<>();
 
         paths.put("/api/v1/auth/register", pathPost(postPublic("Auth", "Registrar usuario", "Cria uma nova conta, empresa inicial quando aplicavel, usuario OWNER/ADMIN e retorna tokens de autenticacao.", "RegisterRequest")));
-        paths.put("/api/v1/auth/authenticate", pathPost(postPublic("Auth", "Autenticar usuario", "Valida email e senha e retorna access token e refresh token da sessao.", "AuthenticationRequest")));
+        paths.put("/api/v1/auth/authenticate", pathPost(postPublic("Auth", "Autenticar usuario", "Valida email e senha e retorna um access token de curta duracao para a sessao BFF.", "AuthenticationRequest")));
         paths.put("/api/v1/auth/forgot-password", pathPost(postPublic("Auth", "Solicitar recuperacao de senha", "Recebe o email do usuario e inicia o fluxo de recuperacao de senha.", "ForgotPasswordRequest")));
         paths.put("/api/v1/auth/reset-password", pathPost(postPublic("Auth", "Redefinir senha", "Valida token de recuperacao e troca a senha do usuario.", "ResetPasswordRequest")));
         paths.put("/api/v1/auth/complete-registration", pathPost(post("Auth", "Concluir cadastro convidado", "Completa os dados de um usuario previamente convidado para uma equipe.", "CompleteRegistrationRequest")));
@@ -869,7 +869,6 @@ public class OpenApiController {
         switch (responseName) {
             case "AuthResponse":
                 properties.put("token", Map.of("type", "string", "example", "<jwt-token>"));
-                properties.put("refreshToken", Map.of("type", "string", "example", "<refresh-token>"));
                 properties.put("user", Map.of(
                     "type", "object",
                     "properties", Map.of(

--- a/Backend/java-app1/demo/src/test/java/com/escala/authservice/config/SecurityConfigurationCorsTest.java
+++ b/Backend/java-app1/demo/src/test/java/com/escala/authservice/config/SecurityConfigurationCorsTest.java
@@ -1,0 +1,32 @@
+package com.escala.authservice.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.cors.CorsConfiguration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class SecurityConfigurationCorsTest {
+
+    @Test
+    void rejectsAnUnconfiguredOriginAndDoesNotAllowCookies() {
+        SecurityConfiguration configuration = new SecurityConfiguration(
+                mock(JwtAuthenticationFilter.class),
+                mock(TenantIsolationFilter.class),
+                mock(AuthenticationProvider.class)
+        );
+        ReflectionTestUtils.setField(configuration, "allowedOrigins", "https://app.escala.example");
+
+        CorsConfiguration cors = configuration.corsConfigurationSource()
+                .getCorsConfiguration(new org.springframework.mock.web.MockHttpServletRequest());
+
+        assertEquals("https://app.escala.example", cors.checkOrigin("https://app.escala.example"));
+        assertNull(cors.checkOrigin("https://evil.example"));
+        assertEquals(Boolean.FALSE, cors.getAllowCredentials());
+        assertTrue(cors.getAllowedHeaders().contains("Authorization"));
+    }
+}

--- a/Frontend/web-app3/escala/src/app/api/bff/auth/complete-registration/route.ts
+++ b/Frontend/web-app3/escala/src/app/api/bff/auth/complete-registration/route.ts
@@ -1,8 +1,12 @@
 import { NextResponse } from 'next/server';
 import { ENV } from '@/constants/env';
 import { getOptionalServerAccessToken } from '@/lib/auth/server-auth';
+import { rejectCrossSiteBffRequest } from '@/lib/bff/request-origin';
 
 export async function POST(request: Request) {
+  const originError = rejectCrossSiteBffRequest(request);
+  if (originError) return originError;
+
   const accessToken = await getOptionalServerAccessToken();
   if (!accessToken) {
     return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });

--- a/Frontend/web-app3/escala/src/app/api/bff/leads/route.ts
+++ b/Frontend/web-app3/escala/src/app/api/bff/leads/route.ts
@@ -3,6 +3,7 @@ import { ENV } from '@/constants/env';
 import { enforceRateLimit } from '@/lib/bff/rate-limit';
 import { getMarketingAttribution } from '@/services/campaign';
 import { LeadCapturePayload } from '@/types/campaign';
+import { rejectCrossSiteBffRequest } from '@/lib/bff/request-origin';
 
 const ALLOWED_METHODS = ['POST'] as const;
 
@@ -48,6 +49,9 @@ export async function POST(request: NextRequest) {
   if (!ALLOWED_METHODS.includes(request.method as (typeof ALLOWED_METHODS)[number])) {
     return jsonError('Metodo nao permitido', 405);
   }
+
+  const originError = rejectCrossSiteBffRequest(request);
+  if (originError) return originError;
 
   let payload: LeadCapturePayload & Record<string, unknown>;
   try {

--- a/Frontend/web-app3/escala/src/app/api/server/[...endpoint]/route.ts
+++ b/Frontend/web-app3/escala/src/app/api/server/[...endpoint]/route.ts
@@ -3,6 +3,7 @@ import { getToken } from 'next-auth/jwt';
 import { NextRequest, NextResponse } from 'next/server';
 import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 import { ENV } from '@/constants/env';
+import { rejectCrossSiteBffRequest } from '@/lib/bff/request-origin';
 
 type RouteContext = {
   params: Promise<{
@@ -134,6 +135,9 @@ async function proxyToBackend(request: NextRequest, context: RouteContext) {
   if (!ALLOWED_METHODS.includes(request.method as (typeof ALLOWED_METHODS)[number])) {
     return jsonError('Metodo nao permitido', 405);
   }
+
+  const originError = rejectCrossSiteBffRequest(request);
+  if (originError) return originError;
 
   const jwt = await getToken({ req: request, secret: process.env.NEXTAUTH_SECRET });
   const accessToken = typeof jwt?.accessToken === 'string' ? jwt.accessToken : undefined;

--- a/Frontend/web-app3/escala/src/lib/bff/backend.ts
+++ b/Frontend/web-app3/escala/src/lib/bff/backend.ts
@@ -2,6 +2,7 @@ import { getToken } from 'next-auth/jwt';
 import { NextResponse } from 'next/server';
 import { ENV } from '@/constants/env';
 import { getOptionalServerAccessToken } from '@/lib/auth/server-auth';
+import { rejectCrossSiteBffRequest } from '@/lib/bff/request-origin';
 
 type BackendRequestOptions = {
   method?: string;
@@ -13,6 +14,11 @@ type BackendRequestOptions = {
 };
 
 export async function proxyBackend(path: string, options: BackendRequestOptions = {}) {
+  if (options.request) {
+    const originError = rejectCrossSiteBffRequest(options.request);
+    if (originError) return originError;
+  }
+
   const url = new URL(path, ENV.API_BASE_URL);
   if (options.searchParams) {
     options.searchParams.forEach((value, key) => url.searchParams.set(key, value));
@@ -50,12 +56,6 @@ export async function proxyBackend(path: string, options: BackendRequestOptions 
 
   if (options.authenticated !== false) {
     let accessToken: string | undefined;
-    const incomingAuthorization = options.request?.headers.get('authorization');
-
-    if (incomingAuthorization?.startsWith('Bearer ')) {
-      accessToken = incomingAuthorization.slice('Bearer '.length).trim();
-    }
-
     // 1. Tenta extrair o token do cookie (NextAuth) se houver requisição
     if (options.request) {
       const jwtToken = await getToken({

--- a/Frontend/web-app3/escala/src/lib/bff/request-origin.ts
+++ b/Frontend/web-app3/escala/src/lib/bff/request-origin.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { ENV } from '@/constants/env';
+
+const UNSAFE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+function appOrigin() {
+  try {
+    return new URL(ENV.APP_URL).origin;
+  } catch {
+    return null;
+  }
+}
+
+/** The BFF uses an HttpOnly NextAuth cookie, so mutations must be same-origin. */
+export function rejectCrossSiteBffRequest(request: Request): NextResponse | null {
+  if (!UNSAFE_METHODS.has(request.method.toUpperCase())) return null;
+
+  const expectedOrigin = appOrigin();
+  const origin = request.headers.get('origin');
+  if (!expectedOrigin || !origin || origin !== expectedOrigin) {
+    return NextResponse.json(
+      { message: 'Origem da requisicao nao permitida' },
+      { status: 403, headers: { 'Cache-Control': 'no-store', 'X-Content-Type-Options': 'nosniff', 'Referrer-Policy': 'strict-origin-when-cross-origin' } }
+    );
+  }
+
+  return null;
+}

--- a/docs/adr-008-autenticacao-bff-nextauth-spring.md
+++ b/docs/adr-008-autenticacao-bff-nextauth-spring.md
@@ -1,0 +1,52 @@
+# ADR-008: Autenticacao BFF/NextAuth e Spring Boot
+
+**Status:** Aceito
+
+**Data:** 2026-09-04
+
+**Decisao relacionada:** issue #55 / P0-12
+
+## Contexto e decisao
+
+O browser autentica a aplicacao pelo NextAuth; o Spring Boot continua stateless e dono da identidade operacional e do isolamento por tenant. A auditoria da issue #55 encontrou que o access token do Spring ja era mantido no JWT criptografado do NextAuth e omitido da resposta `/api/auth/session`, mas o BFF aceitava opcionalmente um `Authorization` enviado pelo browser e rotas mutaveis nao tinham uma verificacao de origem comum.
+
+A decisao e manter um unico modelo: cookie HttpOnly do NextAuth entre browser e BFF; `Authorization: Bearer` somente entre BFF e Spring. O browser nunca recebe, armazena nem reenviara o JWT do Spring.
+
+```text
+Browser -- cookie NextAuth HttpOnly, same-origin --> Next.js BFF
+   |                                                   |
+   | POST /api/auth/* (login/OAuth)                    | Bearer access token (server-side)
+   v                                                   v
+NextAuth ------------------------------------------> Spring Boot
+                                                        |
+                                                        v
+                                           identidade JWT + companyId confiavel
+```
+
+O `companyId` vem exclusivamente do JWT validado pelo Spring e e aplicado por `TenantIsolationFilter`; BFF, payload, query string e cookie nao podem escolher tenant arbitrariamente.
+
+## Transporte, CORS e CSRF
+
+- O JWT de acesso do Spring dura 15 minutos por padrao e fica no JWT criptografado do NextAuth, protegido por `NEXTAUTH_SECRET`. O callback `session` devolve somente perfil minimo; a rota de sessao tambem remove defensivamente qualquer campo `user.token`.
+- Rotas BFF autenticadas leem o access token no servidor. O fallback para `Authorization` recebido do navegador foi removido. Logs de BFF registram somente metodo, path e mensagem de erro, nunca token, cookie, corpo ou segredo.
+- Toda mutacao em `/api/bff/**` e no proxy legado `/api/server/**` exige `Origin` exatamente igual a `NEXT_PUBLIC_APP_URL`/`NEXTAUTH_URL`. Origem ausente, invalida ou externa recebe `403`. Isto protege o cookie HttpOnly contra CSRF; rotas de leitura nao mudam estado.
+- O Spring nao autentica por cookie: recebe Bearer do BFF em rede interna. Por isso CSRF fica desabilitado no Spring e `allowCredentials=false` no CORS. As origens permitidas continuam allowlist explicita em `app.cors.allowed-origins`; origem nao configurada falha no CORS.
+- Login por credenciais e Google acontecem no handler NextAuth sobre HTTPS. O endpoint Spring de autenticacao e chamado server-to-server; Google usa callback e `state`/`nonce` do NextAuth. Em producao `NEXTAUTH_URL` e `NEXT_PUBLIC_APP_URL` devem ser a origem HTTPS canonica, sem curingas.
+
+## Refresh e logout
+
+O backend atual emite apenas access token; nao ha endpoint, DTO ou armazenamento de refresh token. A configuracao historica `JWT_REFRESH_EXPIRATION_MS` nao representa um contrato ativo e nao deve ser usada para supor renovacao silenciosa. A especificacao OpenAPI foi corrigida para nao anunciar `refreshToken`.
+
+Logo, o refresh esta **explicitamente indisponivel** neste release: ao expirar o token, o BFF responde `401` e o cliente volta ao login. Uma futura implementacao precisa de issue propria: refresh token opaco, rotacao a cada uso, hash no servidor, revogacao, expiracao curta, auditoria e transporte apenas no servidor/HttpOnly; nunca em `localStorage` nem na session API.
+
+Logout chama `signOut`, removendo o cookie de sessao NextAuth. Como o Spring usa JWT stateless, um Bearer ja emitido so seria valido na rede interna ate expirar (no maximo 15 minutos); ele nao e exposto ao browser. Revogacao imediata global fica fora deste contrato e exige a mesma evolucao de refresh/revogacao acima. Rollback da mudanca de origem e reverter o commit; nao habilitar CORS credentialed nem restaurar o fallback de Bearer do browser.
+
+## Aceite e operacao
+
+1. Teste unitario do Spring confirma origem CORS configurada aceita, origem externa rejeitada e `allowCredentials=false`.
+2. Teste de navegador: `POST`, `PUT`, `PATCH` e `DELETE` BFF com `Origin` externo ou ausente retornam `403`; a mesma origem canonica funciona autenticada.
+3. Teste de sessao confirma que `/api/auth/session` nao contem `token` nem `accessToken`; DevTools nao mostra Bearer em chamadas browser -> BFF.
+4. Teste de expiracao confirma que, apos 15 minutos, uma chamada BFF autenticada retorna `401` e nao tenta refresh. Teste de logout confirma cookie removido e chamadas BFF posteriores retornam `401`.
+5. Teste de tenant usa um token valido de empresa A contra recurso da empresa B e confirma `403`/`404`, sem aceitar `companyId` enviado pelo client.
+
+Os itens 2 a 5 devem integrar o smoke test autenticado de homologacao antes de uma mudanca de dominio, OAuth, cookie ou proxy. A exposicao de Spring fora do BFF segue a [ADR-007](adr-007-exposicao-servicos-producao.md).

--- a/docs/ambientes.md
+++ b/docs/ambientes.md
@@ -100,6 +100,7 @@ Diretrizes minimas:
 - frontend, backend e Strapi em rede privada quando possivel
 - Redis privado, sem exposicao publica e com auth/TLS quando o provedor suportar
 - Em producao, portas expostas pelo Compose local nao sao permitidas: a matriz de rotas publicas, servicos internos e administracao esta na [ADR-007](adr-007-exposicao-servicos-producao.md).
+- O contrato de autenticacao entre browser, NextAuth/BFF e Spring (cookies, Bearer, CORS, CSRF, logout e ausencia atual de refresh) esta na [ADR-008](adr-008-autenticacao-bff-nextauth-spring.md).
 - banco com backup automatizado e restore testado
 - headers de seguranca no frontend
 - observabilidade de aplicacao e infraestrutura


### PR DESCRIPTION
Summary: hardens the BFF authentication boundary, aligns Spring CORS, corrects OpenAPI, and adds ADR-008.

Validation: backend tests 114/0; frontend lint/typecheck/build; Docker health and OpenAPI 200; cross-origin and missing-origin BFF mutations 403; canonical origin 200.

Closes #55