### PR TITLE
[P0][Security] Revalidate JWT identity state

### DIFF
--- a/Backend/java-app1/demo/src/main/java/com/escala/authservice/config/ApplicationConfig.java
+++ b/Backend/java-app1/demo/src/main/java/com/escala/authservice/config/ApplicationConfig.java
@@ -29,6 +29,7 @@ public class ApplicationConfig {
                 .map(user -> org.springframework.security.core.userdetails.User.builder()
                         .username(resolvePrincipal(username, user.getEmail(), user.getId()))
                         .password(user.getPassword())
+                        .disabled(!user.isActive() || user.getCompany() == null || !user.getCompany().isActive())
                         .authorities(user.getRoles().stream()
                                 .map(role -> role.getName())
                                 .toArray(String[]::new))

--- a/Backend/java-app1/demo/src/main/java/com/escala/authservice/config/JwtAuthenticationFilter.java
+++ b/Backend/java-app1/demo/src/main/java/com/escala/authservice/config/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.escala.authservice.config;
 
 import com.escala.authservice.security.AuthenticatedUserPrincipal;
+import com.escala.authservice.service.AuthoritativeIdentityService;
 import com.escala.authservice.service.JwtService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -11,14 +12,14 @@ import lombok.RequiredArgsConstructor;
 import io.jsonwebtoken.JwtException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -36,7 +37,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     );
 
     private final JwtService jwtService;
-    private final UserDetailsService userDetailsService;
+    private final AuthoritativeIdentityService authoritativeIdentityService;
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
@@ -61,18 +62,22 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             jwt = authHeader.substring(7);
             principalIdentifier = jwtService.extractUsername(jwt);
             if (principalIdentifier != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-                UserDetails userDetails = this.userDetailsService.loadUserByUsername(principalIdentifier);
-                if (jwtService.isTokenValid(jwt, userDetails)) {
+                UUID userId = jwtService.extractUuidClaim(jwt, "id");
+                if (userId != null
+                        && principalIdentifier.equals(userId.toString())
+                        && jwtService.isTokenValidForSubject(jwt, userId)) {
+                    AuthenticatedUserPrincipal principal = authoritativeIdentityService
+                            .resolveActiveIdentity(userId)
+                            .orElse(null);
+                    if (principal == null) {
+                        SecurityContextHolder.clearContext();
+                        filterChain.doFilter(request, response);
+                        return;
+                    }
                     UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
-                            new AuthenticatedUserPrincipal(
-                                    jwtService.extractUuidClaim(jwt, "id"),
-                                    jwtService.extractStringClaim(jwt, "email"),
-                                    jwtService.extractUuidClaim(jwt, "companyId"),
-                                    jwtService.extractStringClaim(jwt, "companySlug"),
-                                    jwtService.extractRoles(jwt)
-                            ),
+                            principal,
                             null,
-                            userDetails.getAuthorities()
+                            principal.roles().stream().map(SimpleGrantedAuthority::new).toList()
                     );
                     authToken.setDetails(
                             new WebAuthenticationDetailsSource().buildDetails(request)
@@ -80,7 +85,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     SecurityContextHolder.getContext().setAuthentication(authToken);
                 }
             }
-        } catch (JwtException | IllegalArgumentException | UsernameNotFoundException exception) {
+        } catch (JwtException | IllegalArgumentException exception) {
             SecurityContextHolder.clearContext();
         }
         filterChain.doFilter(request, response);

--- a/Backend/java-app1/demo/src/main/java/com/escala/authservice/service/AuthoritativeIdentityService.java
+++ b/Backend/java-app1/demo/src/main/java/com/escala/authservice/service/AuthoritativeIdentityService.java
@@ -1,0 +1,50 @@
+package com.escala.authservice.service;
+
+import com.escala.authservice.entity.Role;
+import com.escala.authservice.entity.User;
+import com.escala.authservice.repository.UserRepository;
+import com.escala.authservice.security.AuthenticatedUserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Resolves the current authorization state for a JWT subject. JWT claims are
+ * intentionally not authoritative for tenant, roles, or account activity.
+ */
+@Service
+@RequiredArgsConstructor
+public class AuthoritativeIdentityService {
+
+    private final UserRepository userRepository;
+
+    public Optional<AuthenticatedUserPrincipal> resolveActiveIdentity(UUID userId) {
+        return userRepository.findById(userId)
+                .filter(this::isEligibleForAuthentication)
+                .map(this::toPrincipal);
+    }
+
+    private boolean isEligibleForAuthentication(User user) {
+        return user.isActive()
+                && user.getCompany() != null
+                && user.getCompany().isActive();
+    }
+
+    private AuthenticatedUserPrincipal toPrincipal(User user) {
+        Set<String> roles = user.getRoles() == null
+                ? Set.of()
+                : user.getRoles().stream().map(Role::getName).collect(Collectors.toUnmodifiableSet());
+
+        return new AuthenticatedUserPrincipal(
+                user.getId(),
+                user.getEmail(),
+                user.getCompany().getId(),
+                user.getCompany().getSlug(),
+                roles
+        );
+    }
+}

--- a/Backend/java-app1/demo/src/main/java/com/escala/authservice/service/JwtService.java
+++ b/Backend/java-app1/demo/src/main/java/com/escala/authservice/service/JwtService.java
@@ -91,6 +91,13 @@ public class JwtService {
         return (username.equals(userDetails.getUsername())) && !isTokenExpired(token);
     }
 
+    public boolean isTokenValidForSubject(String token, UUID userId) {
+        if (userId == null) {
+            return false;
+        }
+        return userId.toString().equals(extractUsername(token)) && !isTokenExpired(token);
+    }
+
     private boolean isTokenExpired(String token) {
         return extractExpiration(token).before(new Date());
     }

--- a/Backend/java-app1/demo/src/main/java/com/escala/authservice/service/UserManagementService.java
+++ b/Backend/java-app1/demo/src/main/java/com/escala/authservice/service/UserManagementService.java
@@ -141,7 +141,7 @@ public class UserManagementService {
                 .orElseGet(() -> roleRepository.save(Role.builder().name(roleName).build()));
         user.getRoles().add(role);
         User saved = userRepository.save(user);
-        auditGlobalAccess(requester, "GRANT_ROLE", user);
+        auditIdentityChange(requester, "GRANT_ROLE", user, roleName);
         return saved;
     }
 
@@ -162,7 +162,7 @@ public class UserManagementService {
 
         user.getRoles().removeIf(role -> role.getName().equals(roleName));
         User saved = userRepository.save(user);
-        auditGlobalAccess(requester, "REVOKE_ROLE", user);
+        auditIdentityChange(requester, "REVOKE_ROLE", user, roleName);
         return saved;
     }
 
@@ -254,5 +254,13 @@ public class UserManagementService {
                 : "all";
         auditLogService.record(actor.getEmail(), action, "User", target == null ? null : target.getId(),
                 "Privileged SYSTEM_ADMIN access; targetTenant=" + targetTenant);
+    }
+
+    private void auditIdentityChange(User actor, String action, User target, String roleName) {
+        String targetTenant = target != null && target.getCompany() != null
+                ? String.valueOf(target.getCompany().getId())
+                : "unknown";
+        auditLogService.record(actor.getEmail(), action, "User", target == null ? null : target.getId(),
+                "role=" + roleName + "; targetTenant=" + targetTenant);
     }
 }

--- a/Backend/java-app1/demo/src/test/java/com/escala/authservice/config/JwtAuthenticationFilterTest.java
+++ b/Backend/java-app1/demo/src/test/java/com/escala/authservice/config/JwtAuthenticationFilterTest.java
@@ -1,0 +1,75 @@
+package com.escala.authservice.config;
+
+import com.escala.authservice.security.AuthenticatedUserPrincipal;
+import com.escala.authservice.service.AuthoritativeIdentityService;
+import com.escala.authservice.service.JwtService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class JwtAuthenticationFilterTest {
+
+    private final JwtService jwtService = mock(JwtService.class);
+    private final AuthoritativeIdentityService identityService = mock(AuthoritativeIdentityService.class);
+    private final JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtService, identityService);
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void replacesStaleJwtRolesAndTenantWithTheAuthoritativeIdentity() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID currentCompanyId = UUID.randomUUID();
+        AuthenticatedUserPrincipal currentIdentity = new AuthenticatedUserPrincipal(
+                userId, "user@example.com", currentCompanyId, "tenant-current", Set.of("USER")
+        );
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer signed-token");
+
+        when(jwtService.extractUsername("signed-token")).thenReturn(userId.toString());
+        when(jwtService.extractUuidClaim("signed-token", "id")).thenReturn(userId);
+        when(jwtService.isTokenValidForSubject("signed-token", userId)).thenReturn(true);
+        when(identityService.resolveActiveIdentity(userId)).thenReturn(Optional.of(currentIdentity));
+
+        filter.doFilter(request, new MockHttpServletResponse(), (req, res) -> {
+            var authentication = SecurityContextHolder.getContext().getAuthentication();
+            var principal = (AuthenticatedUserPrincipal) authentication.getPrincipal();
+            assertEquals(currentCompanyId, principal.companyId());
+            assertEquals(Set.of("USER"), principal.roles());
+            assertTrue(authentication.getAuthorities().stream().anyMatch(role -> role.getAuthority().equals("USER")));
+            assertFalse(authentication.getAuthorities().stream().anyMatch(role -> role.getAuthority().equals("ADMIN")));
+        });
+    }
+
+    @Test
+    void rejectsAValidlySignedTokenForAUserThatIsNoLongerActive() throws Exception {
+        UUID userId = UUID.randomUUID();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer signed-token");
+
+        when(jwtService.extractUsername("signed-token")).thenReturn(userId.toString());
+        when(jwtService.extractUuidClaim("signed-token", "id")).thenReturn(userId);
+        when(jwtService.isTokenValidForSubject("signed-token", userId)).thenReturn(true);
+        when(identityService.resolveActiveIdentity(userId)).thenReturn(Optional.empty());
+
+        filter.doFilter(request, new MockHttpServletResponse(), (req, res) ->
+                assertFalse(SecurityContextHolder.getContext().getAuthentication() != null));
+
+        verify(identityService).resolveActiveIdentity(userId);
+    }
+}

--- a/Backend/java-app1/demo/src/test/java/com/escala/authservice/service/AuthoritativeIdentityServiceTest.java
+++ b/Backend/java-app1/demo/src/test/java/com/escala/authservice/service/AuthoritativeIdentityServiceTest.java
@@ -1,0 +1,62 @@
+package com.escala.authservice.service;
+
+import com.escala.authservice.entity.Company;
+import com.escala.authservice.entity.Role;
+import com.escala.authservice.entity.User;
+import com.escala.authservice.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AuthoritativeIdentityServiceTest {
+
+    private final UserRepository userRepository = mock(UserRepository.class);
+    private final AuthoritativeIdentityService service = new AuthoritativeIdentityService(userRepository);
+
+    @Test
+    void rejectsDisabledUsersEvenWhenTheirJwtWouldStillBeValid() {
+        UUID userId = UUID.randomUUID();
+        User user = user(userId, true, false, Set.of("ADMIN"));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        assertFalse(service.resolveActiveIdentity(userId).isPresent());
+    }
+
+    @Test
+    void usesCurrentTenantAndRolesInsteadOfJwtClaims() {
+        UUID userId = UUID.randomUUID();
+        User user = user(userId, true, true, Set.of("USER"));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        var identity = service.resolveActiveIdentity(userId);
+
+        assertTrue(identity.isPresent());
+        assertEquals(user.getCompany().getId(), identity.orElseThrow().companyId());
+        assertEquals(Set.of("USER"), identity.orElseThrow().roles());
+    }
+
+    private User user(UUID userId, boolean companyActive, boolean userActive, Set<String> roleNames) {
+        Company company = Company.builder()
+                .id(UUID.randomUUID())
+                .slug("tenant-current")
+                .active(companyActive)
+                .build();
+        Set<Role> roles = roleNames.stream().map(name -> Role.builder().name(name).build()).collect(java.util.stream.Collectors.toSet());
+        return User.builder()
+                .id(userId)
+                .email("user@example.com")
+                .password("encoded")
+                .company(company)
+                .roles(roles)
+                .active(userActive)
+                .build();
+    }
+}

--- a/Frontend/web-app3/escala/src/proxy.ts
+++ b/Frontend/web-app3/escala/src/proxy.ts
@@ -6,6 +6,13 @@ import { routing } from './i18n/routing';
 const intlMiddleware = createMiddleware(routing);
 
 const PRIVATE_ROUTES = ['/dashboard', '/users'];
+const ACCESS_TOKEN_EXPIRY_SKEW_MS = 5_000;
+const NEXTAUTH_SESSION_COOKIES = [
+  'next-auth.session-token',
+  '__Secure-next-auth.session-token',
+  'authjs.session-token',
+  '__Secure-authjs.session-token',
+];
 
 function stripLocale(pathname: string) {
   return pathname.replace(/^\/[a-z]{2}(-[A-Z]{2})?(\/|$)/, '/');
@@ -15,6 +22,29 @@ function getLocalePrefix(pathname: string) {
   const localeMatch = pathname.match(/^\/([a-z]{2}(?:-[A-Z]{2})?)(?=\/|$)/);
   if (!localeMatch || localeMatch[1] === routing.defaultLocale) return '';
   return `/${localeMatch[1]}`;
+}
+
+function hasValidAccessToken(token: Awaited<ReturnType<typeof getToken>>) {
+  if (!token || typeof token === 'string') {
+    return false;
+  }
+
+  const jwt = token as Record<string, unknown>;
+  if (typeof jwt.accessToken !== 'string' || jwt.accessToken.trim() === '') return false;
+
+  const expiresAt = typeof jwt.accessTokenExpiresAt === 'number'
+    ? jwt.accessTokenExpiresAt
+    : typeof jwt.exp === 'number'
+      ? jwt.exp * 1000
+      : null;
+
+  return expiresAt !== null && expiresAt > Date.now() + ACCESS_TOKEN_EXPIRY_SKEW_MS;
+}
+
+function clearExpiredSession(response: NextResponse) {
+  for (const cookieName of NEXTAUTH_SESSION_COOKIES) {
+    response.cookies.delete(cookieName);
+  }
 }
 
 export async function proxy(req: NextRequest) {
@@ -33,13 +63,16 @@ export async function proxy(req: NextRequest) {
       secret: process.env.NEXTAUTH_SECRET ?? process.env.AUTH_SECRET,
     });
 
-    if (token) {
+    if (hasValidAccessToken(token)) {
       response = intlMiddleware(req);
     } else {
       const loginUrl = req.nextUrl.clone();
       loginUrl.pathname = `${getLocalePrefix(req.nextUrl.pathname)}/login`;
       loginUrl.searchParams.set('callbackUrl', `${req.nextUrl.pathname}${req.nextUrl.search}`);
       response = NextResponse.redirect(loginUrl);
+      if (token) {
+        clearExpiredSession(response);
+      }
     }
   }
 

--- a/docs/adr-008-autenticacao-bff-nextauth-spring.md
+++ b/docs/adr-008-autenticacao-bff-nextauth-spring.md
@@ -23,7 +23,7 @@ NextAuth ------------------------------------------> Spring Boot
                                            identidade JWT + companyId confiavel
 ```
 
-O `companyId` vem exclusivamente do JWT validado pelo Spring e e aplicado por `TenantIsolationFilter`; BFF, payload, query string e cookie nao podem escolher tenant arbitrariamente.
+O JWT identifica somente o sujeito assinado. A cada request autenticada, o Spring resolve novamente usuario ativo, empresa e roles no banco e aplica o `companyId` atual via `TenantIsolationFilter`; BFF, payload, query string e cookie nao podem escolher tenant arbitrariamente.
 
 ## Transporte, CORS e CSRF
 

--- a/docs/adr-009-revalidacao-jwt-estado-autoritativo.md
+++ b/docs/adr-009-revalidacao-jwt-estado-autoritativo.md
@@ -1,0 +1,40 @@
+# ADR-009: Revalidacao de JWT contra estado autoritativo
+
+**Status:** Aceito
+
+**Data:** 2026-09-04
+
+**Decisao relacionada:** issue #56 / P0-13
+
+## Decisao
+
+O access token JWT continua curto, com 15 minutos por padrao, e prova apenas que o sujeito foi autenticado no momento da emissao. Em toda requisicao Bearer, antes de criar o `SecurityContext`, o backend consulta o usuario atual pelo `id` assinado e reconstrui a identidade com `active`, empresa, slug e roles atuais.
+
+Claims de `roles`, `companyId`, `companySlug` e email presentes no token nao sao fonte de autorizacao. O filtro exige que `sub` e o claim `id` assinado coincidam e que o usuario e sua empresa estejam ativos; em qualquer ausencia, inconsistência ou erro de validacao a autenticacao falha fechada. O principal e as authorities passam a refletir somente o banco.
+
+```text
+Bearer JWT assinado (sub/id) -> usuario atual no banco -> ativo + empresa ativa?
+                                                        | nao
+                                                        v
+                                                     401/sem contexto
+                                                        |
+                                                       sim
+                                                        v
+                                  principal/roles/tenant atuais -> policy/filtro tenant
+```
+
+## Semantica de revogacao
+
+- Desativar usuario ou empresa bloqueia imediatamente qualquer access token existente na proxima chamada; login novo ja bloqueava usuario inativo.
+- Remover/adicionar role e mover usuario entre tenants passam a valer na proxima chamada: roles e tenant antigos do JWT nao sao usados.
+- Mudancas de role sao registradas em auditoria com ator, alvo, role e tenant do alvo.
+- Logout do produto continua removendo a sessao NextAuth. Como o Bearer fica apenas na fronteira interna BFF -> Spring, nao existe token de browser para revogar no logout. Uma credencial interna emitida antes do logout ainda e sujeita a expiracao curta e a revalidacao acima.
+- Nao ha refresh token ou endpoint de refresh no contrato atual. Logo nao existe refresh a ser emitido para usuario desativado; qualquer implementacao futura deve consultar o mesmo estado autoritativo, rotacionar token opaco e registrar revogacao.
+
+Nao e mantida blacklist global de tokens: ela nao e necessaria para as transicoes de identidade administradas, pois a consulta autoritativa neutraliza os claims antigos imediatamente. Uma blacklist pode ser introduzida por incidente de comprometimento, com TTL maximo igual ao access token e sem substituir esta revalidacao.
+
+## Testes e rollback
+
+Os testes cobrem usuario desativado com JWT tecnicamente valido e a substituicao de role/tenant antigo pela identidade atual. A suite existente cobre autenticacao inativa e as policies tenant-aware; homologacao deve exercitar desativacao, alteracao de role e troca de tenant contra endpoints protegidos.
+
+O rollback e reverter este commit, sem migracao ou estado de sessao persistido. Isso restaura a validacao anterior, mas reabre a janela maxima de 15 minutos para claims antigos; nao ha dados de usuario ou tokens para recuperar.

--- a/docs/ambientes.md
+++ b/docs/ambientes.md
@@ -101,6 +101,7 @@ Diretrizes minimas:
 - Redis privado, sem exposicao publica e com auth/TLS quando o provedor suportar
 - Em producao, portas expostas pelo Compose local nao sao permitidas: a matriz de rotas publicas, servicos internos e administracao esta na [ADR-007](adr-007-exposicao-servicos-producao.md).
 - O contrato de autenticacao entre browser, NextAuth/BFF e Spring (cookies, Bearer, CORS, CSRF, logout e ausencia atual de refresh) esta na [ADR-008](adr-008-autenticacao-bff-nextauth-spring.md).
+- A revalidacao de usuario, roles e tenant para cada access token esta definida na [ADR-009](adr-009-revalidacao-jwt-estado-autoritativo.md).
 - banco com backup automatizado e restore testado
 - headers de seguranca no frontend
 - observabilidade de aplicacao e infraestrutura


### PR DESCRIPTION
Summary: revalidates active user, tenant and roles from authoritative state for every JWT request; audits role changes; documents the revocation model in ADR-009.

Validation: backend tests 118/0; frontend lint/typecheck/build; Docker backend health and OpenAPI 200.

Closes #56