### PR TITLE
docs: promover governança de plugins e AppSec para main (#91, #93)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - O posicionamento de produto vigente esta documentado em `docs/Analise-Produto-Arquitetura-Concorrencia-Oceano-Azul.md`.
 - OKRs e roadmap atuais estao em `docs/okr.md` e `docs/roadmap.md`.
 - O plano de implementacao da gestao mensal inteligente de escalas esta em `docs/plano-implementacao-gestao-mensal-inteligente-escalas.md`.
+- O uso oficial de ferramentas/plugins para estrategia, Product Design, UX/UI, go-to-market e analytics esta documentado em `docs/ferramentas-ai-product-design-go-to-market.md`.
 
 ## Arquitetura alvo
 
@@ -329,3 +330,50 @@ Para repositórios com proteção de branch, `merge para develop e main` signifi
 3. verificar build;
 4. apresentar git diff;
 5. informar riscos ou pendências.
+
+## Uso de plugins e ferramentas assistivas pelo Codex
+
+Referencia detalhada: `docs/ferramentas-ai-product-design-go-to-market.md`.
+
+### Principio
+
+Plugins sao ferramentas de trabalho para discovery, design, implementacao assistida, marketing, vendas e analytics. Eles **nao sao dependencias do runtime** do Escala. Nao adicionar SDK, API ou integracao de um plugin ao Spring Boot, Next.js ou Strapi apenas porque a ferramenta esta disponivel.
+
+### Ferramentas adotadas e quando usar
+
+- **Business Strategy Builder:** estrategia, escolhas, trade-offs e Business Strategy Canvas.
+- **B2B Messaging Workshop:** ICP, alternativas, diferenciacao, proposta de valor, positioning e matriz de claims/evidencias.
+- **Deep Research:** pesquisa externa de mercado, concorrencia, regulacao e tendencias, sempre com fontes.
+- **Product Design:** discovery, auditoria de UX, user flows e prototipos antes de features de alto custo.
+- **Mobbin:** benchmarking de padroes UX/UI; usar como referencia, nunca para clonar identidade ou assets proprietarios.
+- **Figma:** fonte de verdade visual para telas aprovadas, Design System, tokens, componentes e handoff para implementacao.
+- **Themely Design+Style Generator:** exploracao visual inicial; nao substitui o Figma como fonte de verdade.
+- **Font Pairing: Design & Brands:** exploracao tipografica, sujeita a validacao de licenca, acessibilidade e performance.
+- **Build Web Data Visualization:** dashboards, graficos, Gantt, UML e visualizacoes implementadas no frontend quando houver metrica/requisito definido.
+- **Creative Production:** moodboards, conceitos de campanha e assets, respeitando identidade e claims aprovados.
+- **Sales:** discovery comercial, demo, business case, pipeline e follow-up; dados reais devem seguir minimizacao e LGPD.
+- **Data Analytics:** metricas de produto/negocio, funil, retention e trial -> paid; evitar analise cross-tenant identificavel sem desenho de privacidade.
+- **BuildBetter.ai:** consolidacao de feedback/calls/documentos quando houver volume suficiente de evidencias; nao substitui backlog/docs oficiais.
+
+Ferramentas explicitamente nao adotadas neste momento: **UX Pilot, Zoho CRM e Mailchimp**.
+
+### Fluxo preferencial para features com impacto de UX/produto
+
+1. validar problema e evidencia;
+2. revisar estrategia/posicionamento quando aplicavel;
+3. pesquisar referencias com Mobbin sem copiar terceiros;
+4. explorar fluxo/prototipo com Product Design;
+5. consolidar UI/Design System no Figma quando a mudanca for visual relevante;
+6. revisar acessibilidade, responsividade, loading, empty, error e permissoes;
+7. somente entao implementar no repositorio seguindo os gates tecnicos existentes;
+8. instrumentar metricas quando houver finalidade e definicao de evento;
+9. usar Data Analytics/BuildBetter para fechar o ciclo de aprendizado.
+
+### Regras de seguranca e governanca para plugins
+
+- Nao enviar secrets, tokens, chaves AWS, dumps de banco ou credenciais a ferramentas de design/marketing.
+- Preferir dados ficticios, sinteticos ou anonimizados em prototipos e materiais externos.
+- Nenhum output de IA pode decidir autorizacao, tenant, efetivar operacao privilegiada ou substituir validacao backend.
+- Claims sobre LGPD, Portaria 671, conformidade trabalhista, reducao de custo ou ganho percentual exigem evidencia adequada antes de publicacao.
+- Outputs de plugins devem ser revisados antes de entrar em codigo, documentacao oficial, marketing, contrato ou regra de negocio.
+- Novo plugin exige justificativa de problema, sobreposicao, custo, permissoes/dados, LGPD, lock-in e metrica de sucesso.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 - OKRs e roadmap atuais estao em `docs/okr.md` e `docs/roadmap.md`.
 - O plano de implementacao da gestao mensal inteligente de escalas esta em `docs/plano-implementacao-gestao-mensal-inteligente-escalas.md`.
 - O uso oficial de ferramentas/plugins para estrategia, Product Design, UX/UI, go-to-market e analytics esta documentado em `docs/ferramentas-ai-product-design-go-to-market.md`.
+- A politica oficial de AppSec, Definition of Ready/Done e criterios de aceite para contratos, comunicacoes e regras de negocio esta em `docs/appsec-criterios-de-aceite.md`.
 
 ## Arquitetura alvo
 
@@ -377,3 +378,59 @@ Ferramentas explicitamente nao adotadas neste momento: **UX Pilot, Zoho CRM e Ma
 - Claims sobre LGPD, Portaria 671, conformidade trabalhista, reducao de custo ou ganho percentual exigem evidencia adequada antes de publicacao.
 - Outputs de plugins devem ser revisados antes de entrar em codigo, documentacao oficial, marketing, contrato ou regra de negocio.
 - Novo plugin exige justificativa de problema, sobreposicao, custo, permissoes/dados, LGPD, lock-in e metrica de sucesso.
+
+## AppSec e criterios de aceite obrigatorios
+
+Referencia detalhada: `docs/appsec-criterios-de-aceite.md`.
+
+### Ferramentas de seguranca
+
+- **Codex Security** e a ferramenta assistiva prioritaria para scans, analise e investigacao de seguranca do codigo/configuracao quando disponivel.
+- GitHub/CI continua sendo a autoridade para checks e merge.
+- Codex Security nao substitui SAST/CodeQL, dependency scanning, secret scanning, testes de autorizacao, threat modeling ou revisao humana.
+- ArmorCodex, se adotado futuramente, serve para governanca de agentes e approvals; nao substitui scanner AppSec.
+- Scanners externos de privacidade/DNS podem complementar producao publica, mas nao alteram regras de seguranca do backend.
+
+### Definition of Ready obrigatoria
+
+Antes de implementar feature relevante, definir conforme aplicavel:
+
+1. problema, ator e valor;
+2. criterios de aceite funcionais;
+3. contrato tecnico ou ausencia de mudanca contratual;
+4. regras de negocio e invariantes;
+5. autorizacao e impacto multi-tenant;
+6. impacto LGPD/compliance;
+7. estados UX relevantes;
+8. dependencias externas e riscos.
+
+### Criterios de aceite de contratos
+
+Mudancas REST/BFF/eventos devem declarar produtor/consumidor, schema, autenticacao, autorizacao, tenant, sucesso/erros, compatibilidade, idempotencia quando aplicavel, observabilidade e testes. Mudancas REST exigem atualizacao do OpenAPI manual enquanto este for o mecanismo vigente.
+
+### Criterios de aceite de comunicacoes
+
+Email, in-app, push e mensagens operacionais devem declarar gatilho, destinatario, canal, conteudo minimo, locale/CTA quando aplicavel, retry/duplicidade, indisponibilidade e auditabilidade. Nenhuma comunicacao pode revelar dados de outro tenant ou substituir autorizacao backend.
+
+### Criterios de aceite de regras de negocio
+
+Toda regra relevante deve explicitar pre-condicoes, atores autorizados, tenant, happy path, casos de borda, invariantes, erros de dominio, efeitos colaterais, concorrencia/idempotencia, observabilidade e testes proporcionais ao risco.
+
+### Definition of Done obrigatoria
+
+Uma issue so deve ser concluida quando, conforme aplicavel:
+
+- criterios de aceite passam;
+- testes unitarios e de integracao/contrato passam;
+- autorizacao negativa e tentativa cross-tenant estao cobertas para recurso tenant-bound;
+- lint/typecheck/build passam;
+- backend inicia em Docker e health/OpenAPI sao validados quando backend foi alterado;
+- docs/OpenAPI foram atualizados;
+- findings criticos/altos relevantes foram corrigidos, mitigados ou possuem aceite formal de risco;
+- auditoria/telemetria necessarias existem;
+- nao ha secrets ou dados sensiveis indevidos no diff;
+- rollback ou estrategia de reversao existe para mudancas de risco.
+
+### Findings que bloqueiam merge/release
+
+Por padrao, finding critico confirmado bloqueia merge/release. Exemplos: cross-tenant leak, auth bypass, segredo valido exposto e execucao remota exploravel. Findings altos normalmente bloqueiam release e exigem correcao ou aceite formal de risco com mitigacao, responsavel e prazo.

--- a/docs/appsec-criterios-de-aceite.md
+++ b/docs/appsec-criterios-de-aceite.md
@@ -1,0 +1,256 @@
+# AppSec e Critérios de Aceite — Escala
+
+Data de referência: 2026-09-07.
+
+## Objetivo
+
+Este documento define como o Escala trata segurança de aplicação e critérios de aceite para contratos técnicos, comunicações e regras de negócio. Ele complementa `AGENTS.md`, `docs/roadmap.md`, os documentos de arquitetura e as decisões de produto.
+
+A regra central é simples: uma feature não está pronta apenas porque o happy path funciona. Ela deve demonstrar contrato explícito, autorização correta, isolamento multi-tenant, comportamento de erro, observabilidade/auditoria quando aplicável e testes proporcionais ao risco.
+
+## 1. AppSec no ciclo de desenvolvimento
+
+### Ferramenta prioritária
+
+- **Codex Security:** ferramenta assistiva prioritária para scans, análise e investigação de segurança do código e da configuração.
+- O uso do plugin não substitui revisão humana, CI, testes automatizados, scanners de dependência, secret scanning, threat modeling ou validação de autorização.
+- Findings devem ser classificados por impacto, explorabilidade, superfície afetada e risco multi-tenant.
+
+### Ferramentas complementares
+
+- **GitHub/CI:** source of truth para PRs, checks obrigatórios e rastreabilidade.
+- **Dependabot/alerts ou scanner equivalente:** dependências vulneráveis e supply chain.
+- **Secret scanning:** segredos expostos em histórico, código e configuração.
+- **SAST/CodeQL quando disponível:** análise estática de fluxos inseguros.
+- **DAST em homolog quando justificável:** rotas públicas, autenticação, autorização e headers.
+- **CertScore.ai Privacy Scanner:** útil apenas para auditoria pública de cookies, trackers e sinais de privacidade do site publicado; não substitui avaliação jurídica/LGPD.
+- **Radar Lite:** opcional para DNS, email authentication e postura externa de domínio quando o Escala possuir domínio público de produção.
+- **ArmorCodex:** opcional para governança de agentes e políticas de uso do Codex; não é scanner da aplicação.
+
+Não adicionar SDKs dessas ferramentas ao runtime do Escala sem necessidade funcional, ADR e avaliação de segurança/LGPD.
+
+## 2. Gates mínimos de segurança
+
+Uma mudança de risco relevante não deve ser integrada enquanto houver finding crítico conhecido sem mitigação aceita.
+
+### Gate SEC-01 — Autenticação e autorização
+
+- endpoint privado exige identidade autenticada;
+- autorização deve ser validada no backend, não apenas na UI;
+- role/permissão deve ser explicitada no critério de aceite;
+- IDOR deve ser testado para recursos por identificador;
+- tentativa de acesso por usuário sem permissão deve falhar com resposta consistente e sem vazamento de detalhes.
+
+### Gate SEC-02 — Multi-tenant
+
+- tenant deve vir do principal/contexto server-side;
+- nunca confiar em `tenantId/companyId` arbitrário vindo do cliente;
+- queries tenant-bound devem incluir isolamento explícito;
+- testes devem tentar acesso cross-tenant de leitura e escrita;
+- logs/auditoria devem registrar tenant sem expor PII desnecessária.
+
+### Gate SEC-03 — Entrada, saída e dados
+
+- validar request no boundary;
+- evitar mass assignment e bind direto de entidade persistente;
+- DTOs de resposta devem expor somente campos necessários;
+- uploads devem validar tipo, tamanho, nome, armazenamento e autorização;
+- dados sensíveis devem ser minimizados em logs e erros.
+
+### Gate SEC-04 — Sessão, cookies e frontend
+
+- cookies de sessão devem usar atributos adequados (`HttpOnly`, `Secure` em produção e `SameSite` apropriado);
+- CSP, HSTS, frame protection e políticas de origem devem ser compatíveis com o fluxo real;
+- ações mutáveis devem considerar CSRF conforme o mecanismo de autenticação;
+- conteúdo vindo do CMS não pode permitir XSS arbitrário.
+
+### Gate SEC-05 — Supply chain e secrets
+
+- nenhum segredo no repositório;
+- dependências novas exigem justificativa e avaliação de manutenção/licença/risco;
+- vulnerabilidade crítica/alta explorável exige correção, mitigação ou aceite formal de risco antes da produção;
+- imagens Docker e lockfiles devem fazer parte da revisão de supply chain.
+
+### Gate SEC-06 — Auditoria e observabilidade
+
+- operações privilegiadas ou com impacto trabalhista/comercial devem ter rastreabilidade adequada;
+- erros devem possuir correlation/request id quando possível;
+- logs não devem conter senha, token, documento pessoal completo ou payload sensível sem necessidade;
+- eventos de segurança relevantes devem ser distinguíveis de erro funcional comum.
+
+## 3. Critérios de aceite para contratos técnicos
+
+“Contrato” inclui REST, BFF, DTOs, eventos de domínio, mensagens assíncronas e integrações externas.
+
+Toda mudança de contrato deve declarar:
+
+1. consumidor e produtor;
+2. método/rota ou nome do evento;
+3. autenticação e autorização;
+4. escopo de tenant;
+5. request/schema de entrada;
+6. response/schema de saída;
+7. códigos de sucesso e erro;
+8. validações e invariantes relevantes;
+9. idempotência quando houver retry/pagamento/publicação/mensagem;
+10. compatibilidade/backward compatibility ou estratégia de versão;
+11. observabilidade e correlação;
+12. testes de contrato/integracão correspondentes.
+
+### Aceite REST/BFF
+
+Uma mudança REST/BFF só é aceita quando:
+
+- OpenAPI/documentação correspondente foi atualizada;
+- frontend e backend concordam com nomes, tipos, nulabilidade e enumerações;
+- erros previsíveis têm códigos e payload consistentes;
+- autorização e tenant isolation foram testados;
+- dados não necessários não aparecem na resposta;
+- paginação/filtros/ordenação possuem limites e defaults explícitos quando aplicável;
+- mudança breaking é evitada ou possui plano de migração/versionamento.
+
+### Aceite de eventos/mensageria
+
+Quando houver comunicação assíncrona:
+
+- evento deve possuir nome e versão;
+- produtor e consumidores devem ser conhecidos;
+- retry e duplicidade devem ser considerados;
+- consumidor deve ser idempotente quando necessário;
+- falha de envio não pode corromper a transação principal;
+- dead-letter/reprocessamento só deve ser adicionado quando houver justificativa operacional;
+- payload deve respeitar minimização de dados e tenant.
+
+## 4. Critérios de aceite para comunicações
+
+Comunicação inclui email, notificação in-app, push, mensagens para gestores/colaboradores, mensagens de trial/billing e mensagens operacionais.
+
+Toda comunicação deve definir:
+
+- gatilho;
+- destinatário e por que ele pode receber a mensagem;
+- canal;
+- conteúdo mínimo necessário;
+- locale/idioma quando aplicável;
+- CTA/destino;
+- comportamento em retry/duplicidade;
+- auditabilidade quando a comunicação tiver efeito relevante;
+- tratamento de indisponibilidade do provedor.
+
+### Regras de aceite
+
+- não enviar informação de outro tenant;
+- não revelar dado sensível além do necessário;
+- links autenticados devem levar o usuário ao recurso correto e respeitar autorização ao abrir;
+- mensagem não substitui validação backend;
+- envio duplicado deve ser evitado ou tolerável;
+- preferências de comunicação/opt-out devem ser respeitadas quando aplicável;
+- mensagens legais/comerciais devem usar claims aprovados e não prometer conformidade não validada;
+- falha no canal secundário não deve desfazer operação principal já confirmada, salvo regra explícita.
+
+## 5. Critérios de aceite para regras de negócio
+
+Toda regra de negócio relevante deve ter critérios de aceite verificáveis em linguagem de domínio e testes automatizados.
+
+### Template mínimo
+
+**Regra:** descrição em termos de negócio.
+
+**Pré-condições:** estado necessário para executar.
+
+**Atores autorizados:** quem pode executar.
+
+**Tenant:** como o escopo é determinado.
+
+**Happy path:** comportamento esperado.
+
+**Casos de borda:** datas, limites, estados concorrentes, entradas vazias, timezone, etc.
+
+**Invariantes:** o que nunca pode ocorrer.
+
+**Erros de domínio:** códigos/mensagens esperados.
+
+**Efeitos colaterais:** auditoria, notificação, evento, cobrança, consumo de IA.
+
+**Idempotência/concorrência:** comportamento em retry ou duas ações simultâneas.
+
+**Observabilidade:** logs/métricas/eventos úteis.
+
+**Testes:** unitários, integração e E2E conforme risco.
+
+### Exemplos de invariantes do Escala
+
+- um colaborador não pode possuir duas atribuições incompatíveis no mesmo período;
+- uma troca não pode ser efetivada sem os estados/aprovações exigidos;
+- um gestor não pode operar recurso de tenant ao qual não pertence;
+- publicação de escala deve respeitar as validações e ciência de alertas críticos definidas pelo domínio;
+- limite de plano/IA deve ser aplicado no backend, nunca apenas na UI;
+- webhook/billing não pode gerar cobrança/efeito duplicado por retry;
+- auditoria append-only não pode ser alterada por fluxo normal da aplicação.
+
+## 6. Definition of Ready
+
+Uma issue está pronta para implementação quando, conforme aplicável:
+
+- problema e valor estão claros;
+- atores/personas estão identificados;
+- critérios de aceite funcionais estão escritos;
+- contrato técnico está definido ou impacto contratual declarado como inexistente;
+- regras de negócio/invariantes estão explicitadas;
+- impacto de segurança e multi-tenant foi avaliado;
+- impacto LGPD/compliance foi avaliado;
+- estados UX de loading/empty/error/disabled/responsivo foram considerados;
+- dependências externas e riscos estão conhecidos.
+
+## 7. Definition of Done
+
+Uma issue só está concluída quando, conforme aplicável:
+
+- critérios de aceite passam;
+- testes unitários de domínio passam;
+- testes de integração/contrato passam;
+- tentativa cross-tenant e autorização negativa foram cobertas para recurso tenant-bound;
+- lint/typecheck/build passam;
+- backend inicia em Docker e health/OpenAPI são validados quando backend foi alterado;
+- documentação/OpenAPI foi atualizada;
+- findings críticos/altos relevantes de segurança foram tratados;
+- logs/auditoria/telemetria necessários existem;
+- sem secrets ou dados sensíveis indevidos no diff;
+- UX aprovada inclui estados de erro, loading e acessibilidade quando aplicável;
+- rollback ou estratégia de reversão é conhecida para mudanças de risco.
+
+## 8. Severidade e tratamento de findings
+
+- **Crítico:** bloqueia merge/release. Ex.: cross-tenant leak, auth bypass, secret válido exposto, execução remota explorável.
+- **Alto:** normalmente bloqueia release; exige correção ou aceite formal de risco com mitigação e prazo.
+- **Médio:** entra no backlog priorizado com contexto e prazo proporcional ao risco.
+- **Baixo:** pode ser tratado como hardening/qualidade, sem mascarar dívida recorrente.
+
+Finding de ferramenta nunca deve ser aceito ou rejeitado apenas pela severidade automática: validar explorabilidade e contexto real.
+
+## 9. Uso do Codex Security
+
+Usar prioritariamente:
+
+- antes de release relevante;
+- em mudanças de IAM, RBAC/ReBAC, multi-tenant, billing, uploads, sessões, IA com dados sensíveis e integrações externas;
+- após mudança importante de dependências/framework;
+- em investigação de incidente/finding;
+- periodicamente para baseline de segurança.
+
+Saída esperada:
+
+1. finding;
+2. evidência/arquivo/fluxo afetado;
+3. impacto;
+4. explorabilidade;
+5. impacto multi-tenant;
+6. recomendação;
+7. teste de regressão;
+8. decisão: corrigir, mitigar, aceitar risco ou falso positivo.
+
+## 10. Regulatório
+
+- LGPD deve ser avaliada para coleta, finalidade, minimização, retenção, compartilhamento e direitos do titular.
+- Portaria 671 deve ser tratada apenas quando o fluxo realmente entrar no escopo técnico/regulatório de registro eletrônico de ponto; não usar alegação comercial de conformidade sem validação específica.
+- Critérios jurídicos/comerciais que dependam de interpretação legal devem ser revisados por profissional qualificado antes de virar promessa contratual.

--- a/docs/ferramentas-ai-product-design-go-to-market.md
+++ b/docs/ferramentas-ai-product-design-go-to-market.md
@@ -1,0 +1,343 @@
+# Ferramentas de IA, Product Design e Go-to-Market — Escala
+
+Data de referencia: 2026-09-07.
+
+## Objetivo
+
+Este documento define como o projeto Escala deve usar as ferramentas/plugins adotados durante discovery, estrategia, UX/UI, implementacao, marketing, vendas e analytics.
+
+As ferramentas descritas aqui sao **ferramentas de trabalho do time e do Codex/ChatGPT**. Elas nao fazem parte do runtime do SaaS, nao devem ser adicionadas automaticamente como dependencias do Spring Boot, Next.js, Strapi ou PostgreSQL e nao substituem decisoes arquiteturais, revisao humana, testes ou validacao juridica.
+
+## Principio de uso
+
+O fluxo preferencial e:
+
+```text
+Estrategia e mercado
+        ↓
+Discovery e evidencias
+        ↓
+Posicionamento e proposta de valor
+        ↓
+UX / fluxos / prototipos
+        ↓
+Design System
+        ↓
+Implementacao no repositorio
+        ↓
+Validacao tecnica e de seguranca
+        ↓
+Go-to-market e vendas
+        ↓
+Analytics e aprendizado
+        ↺
+```
+
+Nenhum output de ferramenta externa e considerado requisito, decisao arquitetural ou verdade de produto sem revisao e registro no repositorio quando aplicavel.
+
+## Ferramentas adotadas
+
+### Product Design
+
+Uso principal:
+
+- explorar fluxos e alternativas de produto;
+- auditar UX de telas e jornadas existentes;
+- prototipar onboarding, dashboard, escala mensal, trocas, configuracoes e experiencias mobile;
+- validar hierarquia, navegacao, estados vazios, erros e acessibilidade antes de implementar.
+
+Gate para implementacao:
+
+- requisitos e regras de negocio devem continuar documentados no repositorio;
+- prototipo nao define contrato REST nem regra de dominio;
+- fluxos tenant-bound devem explicitar contexto, permissao e estados de erro.
+
+### Figma
+
+Uso principal:
+
+- fonte de verdade visual quando houver design aprovado;
+- Design System, tokens, componentes e variantes;
+- handoff design -> codigo;
+- Code Connect/regras de componentes quando aplicavel.
+
+Diretriz:
+
+- componentes compartilhados devem convergir para tokens reutilizaveis;
+- nao copiar estilos isolados para cada pagina;
+- mudanca no Design System deve considerar acessibilidade, responsividade e impacto nas telas existentes.
+
+### Mobbin
+
+Uso principal:
+
+- pesquisa de referencias e padroes UX/UI de produtos reais;
+- benchmarking de onboarding, dashboards, tabelas, filtros, calendarios, configuracoes, navegacao e mobile.
+
+Restricao:
+
+- usar como referencia, nao como fonte para clonagem de identidade, assets ou experiencia proprietaria de terceiros.
+
+### Themely Design+Style Generator
+
+Uso principal:
+
+- explorar direcoes visuais para dashboard, landing pages e superficies internas;
+- comparar combinacoes de layout, espacamento, tipografia e linguagem visual antes de consolidar no Figma.
+
+Uso secundario; Figma continua sendo a fonte de verdade do design aprovado.
+
+### Font Pairing: Design & Brands
+
+Uso principal:
+
+- explorar combinacoes tipograficas para marca, marketing e Design System.
+
+Qualquer fonte adotada deve ser validada quanto a licenca, performance web, legibilidade, caracteres PT-BR e estrategia de carregamento no Next.js.
+
+### B2B Messaging Workshop
+
+Uso principal:
+
+- ICP;
+- alternativas atuais do cliente;
+- problemas prioritarios;
+- diferenciacao;
+- proposta de valor;
+- positioning;
+- claims e evidencias;
+- Product Marketing source of truth.
+
+Diretriz:
+
+- claims comerciais devem ser classificados como comprovados, hipotese a validar ou proibidos ate evidencia suficiente;
+- evitar promessas absolutas de conformidade trabalhista, LGPD ou Portaria 671 sem validacao tecnica/juridica correspondente.
+
+### Business Strategy Builder
+
+Uso principal:
+
+- consolidar estrategia e trade-offs;
+- Business Strategy Canvas;
+- escolha de segmentos prioritarios;
+- alinhamento entre produto, operacao e go-to-market.
+
+Deve ser usado em conjunto com os documentos de Oceano Azul, SWOT, OKRs e roadmap existentes, sem substitui-los automaticamente.
+
+### Sales
+
+Uso principal:
+
+- estruturar processo comercial B2B;
+- discovery comercial;
+- preparacao de reunioes e demos;
+- business cases;
+- pipeline e forecast quando houver dados;
+- follow-up e materiais de decisao.
+
+A ferramenta nao deve receber dados pessoais ou comerciais de clientes alem do necessario e permitido.
+
+### Creative Production
+
+Uso principal:
+
+- moodboards;
+- conceitos de campanha;
+- assets de lancamento;
+- criativos e social posts;
+- imagens de produto e marketing.
+
+Diretriz:
+
+- identidade visual final deve respeitar o Design System e guidelines da marca;
+- conteudo promocional deve respeitar claims validados pelo B2B Messaging Workshop e pelo repositorio.
+
+### Data Analytics
+
+Uso principal:
+
+- analise de produto e negocio;
+- acquisition, activation, engagement, retention, revenue e conversion;
+- validacao de hipoteses;
+- analise de trial -> paid;
+- segmentacao e acompanhamento de uso.
+
+Nao deve existir analise cross-tenant baseada em dados identificaveis sem desenho explicito de privacidade e autorizacao. Preferir metricas agregadas e minimizadas.
+
+### Build Web Data Visualization
+
+Uso principal no Codex:
+
+- projetar e implementar dashboards, graficos, Gantt, UML e visualizacoes do produto;
+- revisar clareza, acessibilidade e performance de visualizacoes;
+- transformar metricas validadas em componentes Next.js/React quando fizer sentido.
+
+Visualizacao nao substitui definicao de metrica. Toda metrica deve ter owner, formula e fonte de dados conhecida.
+
+### BuildBetter.ai
+
+Uso principal, quando houver volume suficiente de evidencias:
+
+- consolidar feedback de clientes, entrevistas, calls, documentos e sinais de produto;
+- ligar evidencia de cliente a decisoes de produto e engenharia;
+- apoiar priorizacao baseada em evidencias.
+
+Nao deve se tornar fonte unica de verdade. Requisitos aprovados continuam no backlog e docs oficiais.
+
+### Deep Research
+
+Uso principal:
+
+- pesquisa de mercado e concorrencia;
+- regulacao e referencias publicas;
+- tendencias de workforce management;
+- estudo de nichos, pricing e alternativas.
+
+Resultados externos devem ser citados e diferenciados de fatos observados no codigo ou de dados internos.
+
+## Ferramentas nao adotadas neste momento
+
+- UX Pilot;
+- Zoho CRM;
+- Mailchimp.
+
+A nao adocao atual nao e proibicao definitiva. A entrada futura depende de problema real, beneficio mensuravel, custo, risco, privacidade, integracao e sobreposicao com ferramentas ja adotadas.
+
+## Roadmap de uso das ferramentas
+
+### Trilha T0 — Governanca imediata
+
+1. Manter este documento e `AGENTS.md` como orientacao para o Codex.
+2. Nao instalar SDKs ou dependencias de plugins no runtime sem ADR e caso de uso de produto.
+3. Definir quais informacoes podem sair do repositorio/ambiente e quais sao restritas.
+4. Usar dados ficticios ou anonimizados em exploracoes de design e marketing.
+5. Registrar decisoes que afetem produto/arquitetura nos documentos oficiais.
+
+### Trilha T1 — Estrategia e posicionamento
+
+Ferramentas: Business Strategy Builder, B2B Messaging Workshop, Deep Research.
+
+Entregaveis:
+
+- ICP priorizado;
+- Strategy Canvas/Oceano Azul revisado;
+- SWOT revisada com evidencias;
+- proposta de valor por segmento;
+- matriz de claims/evidencias;
+- hipoteses de pricing e go-to-market;
+- atualizacao de OKRs quando necessario.
+
+### Trilha T2 — Product discovery e UX
+
+Ferramentas: Product Design, Mobbin, BuildBetter.ai quando houver evidencia interna suficiente.
+
+Entregaveis:
+
+- jornadas criticas;
+- user flows;
+- problemas de usabilidade;
+- prototipos antes de features de alto custo;
+- criterios de aceitacao de UX e acessibilidade;
+- backlog priorizado por valor, risco e evidencia.
+
+### Trilha T3 — Design System e UI
+
+Ferramentas: Figma, Product Design, Themely, Font Pairing.
+
+Entregaveis:
+
+- foundations/tokens;
+- tipografia e escala visual;
+- componentes e variantes;
+- estados loading/error/empty/disabled;
+- padroes de tabelas, filtros, formularios e calendario;
+- responsividade e acessibilidade WCAG como criterio de aceite.
+
+### Trilha T4 — Implementacao assistida pelo Codex
+
+Ferramentas: GitHub, Figma/Product Design quando houver design aprovado, Build Web Data Visualization para interfaces quantitativas.
+
+Ordem obrigatoria antes de implementar mudanca relevante:
+
+1. explicar o problema;
+2. identificar impacto arquitetural;
+3. apresentar alternativas;
+4. recomendar uma solucao;
+5. indicar riscos;
+6. propor testes;
+7. avaliar seguranca;
+8. avaliar impacto multi-tenant;
+9. somente entao implementar.
+
+Durante a implementacao:
+
+- backend continua sendo autoridade de regras e autorizacao;
+- frontend nao deve confiar em tenantId fornecido pelo cliente;
+- manter contratos REST explicitos;
+- executar gates de teste/lint/build;
+- atualizar OpenAPI manual quando houver mudanca REST;
+- usar PRs e checks conforme `AGENTS.md`.
+
+### Trilha T5 — Go-to-market
+
+Ferramentas: B2B Messaging Workshop, Creative Production, Sales, Strapi e Next.js.
+
+Entregaveis:
+
+- homepage alinhada ao positioning;
+- landing pages por segmento;
+- sales deck e demo narrative;
+- campanhas e assets;
+- formularios e atribuicao de leads;
+- playbook comercial inicial.
+
+Strapi continua sendo a fonte editorial; Spring Boot continua dono de lead operacional, trial, billing e limites.
+
+### Trilha T6 — Analytics e aprendizado continuo
+
+Ferramentas: Data Analytics, Build Web Data Visualization, BuildBetter.ai.
+
+Eventos candidatos:
+
+- `signup_completed`;
+- `tenant_created`;
+- `employee_created`;
+- `schedule_created`;
+- `schedule_validated`;
+- `schedule_published`;
+- `swap_requested`;
+- `trial_started`;
+- `trial_converted`;
+- `subscription_started`;
+- `subscription_cancelled`;
+- `ai_suggestion_requested`;
+- `ai_suggestion_accepted`.
+
+Antes de instrumentar cada evento, definir finalidade, minimizacao, tenant, retencao e se ha dado pessoal envolvido.
+
+## Seguranca, LGPD e multi-tenant
+
+As ferramentas externas nunca alteram as seguintes regras:
+
+- tenant deve ser derivado do principal autenticado no backend;
+- nenhum output de IA pode autorizar acesso ou efetivar operacao privilegiada sozinho;
+- nao enviar secrets, tokens, chaves AWS, dumps de banco ou credenciais a ferramentas de design/marketing;
+- dados de funcionarios/clientes devem ser minimizados, anonimizados ou substituidos por dados sinteticos quando possivel;
+- qualquer integracao futura com dados reais exige avaliacao de suboperador, finalidade, retencao e controles LGPD;
+- outputs de IA devem ser revisados antes de entrar em codigo, marketing, contratos ou documentacao regulatoria.
+
+## Criterio para adicionar um novo plugin
+
+Antes de adotar outra ferramenta, registrar:
+
+1. problema real que ela resolve;
+2. sobreposicao com ferramentas ja adotadas;
+3. impacto arquitetural e operacional;
+4. custo;
+5. dados/permissoes necessarios;
+6. risco de fornecedor e lock-in;
+7. impacto LGPD e multi-tenant;
+8. estrategia de saida;
+9. metrica de sucesso.
+
+Sem justificativa suficiente, preferir o conjunto atual e evitar proliferacao de ferramentas.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap — Gestao Inteligente de Escalas
 
-Data de referencia: 2026-06-30.
+Data de referencia: 2026-09-07.
 
 ## Estrategia de entrega
 
@@ -147,6 +147,78 @@ Status atual:
 - **DevOps:** health checks, Compose por ambiente, secrets obrigatorios fora de dev, backups e CI/CD.
 - **Documentacao:** manter `docs/` como fonte conceitual e atualizar OpenAPI manual ao mudar REST.
 - **Qualidade:** ampliar testes unitarios de dominio e testes de integracao de autenticacao, JPA, JWT e endpoints.
+- **Product/Design/Go-to-Market assistido por IA:** usar o fluxo definido em `docs/ferramentas-ai-product-design-go-to-market.md`, mantendo plugins fora do runtime e submetendo outputs a revisao humana, seguranca, LGPD e governanca do repositorio.
+
+## Trilha transversal — Product, Design e Go-to-Market assistidos por plugins
+
+Esta trilha nao substitui as fases de produto. Ela acompanha todas as fases e define em que momento as ferramentas adotadas agregam valor.
+
+| Etapa | Ferramentas prioritarias | Resultado esperado |
+|---|---|---|
+| Estrategia | Business Strategy Builder, Deep Research | escolhas, trade-offs, nichos, SWOT/Oceano Azul e hipoteses de mercado |
+| Posicionamento | B2B Messaging Workshop | ICP, alternativas, diferenciacao, proposta de valor, claims e evidencias |
+| Discovery | Product Design, Mobbin, BuildBetter.ai quando houver base de evidencias | jornadas, problemas, referencias, hipoteses e criterios de aceitacao |
+| UI/Design System | Figma, Product Design, Themely, Font Pairing | tokens, componentes, variantes, responsividade e acessibilidade |
+| Implementacao | Codex/GitHub, Figma e Build Web Data Visualization quando aplicavel | codigo alinhado ao design e aos contratos, com testes e gates |
+| Marketing | B2B Messaging Workshop, Creative Production, Strapi/Next.js | homepage, landing pages, campanhas e assets coerentes com claims validados |
+| Comercial | Sales | playbook, discovery comercial, demos, business cases, pipeline e follow-up |
+| Analytics | Data Analytics, Build Web Data Visualization | metricas definidas, dashboards, funil trial -> paid e aprendizado de produto |
+| Evidencias | BuildBetter.ai | consolidacao de feedback/calls/documentos para priorizacao baseada em evidencias |
+
+### Roadmap operacional da trilha
+
+#### T0 — Imediato: governanca
+
+- Adotar `docs/ferramentas-ai-product-design-go-to-market.md` como referencia operacional.
+- Nao adicionar SDKs dos plugins ao runtime sem caso de uso de produto, ADR e avaliacao de seguranca/LGPD.
+- Usar dados ficticios ou anonimizados em design, marketing e demonstracoes sempre que possivel.
+- Manter requisitos, regras de negocio e decisoes finais no repositorio.
+
+#### T1 — Estrategia e positioning
+
+- Revisar Strategy Canvas/Oceano Azul e SWOT com Business Strategy Builder + Deep Research.
+- Executar B2B Messaging Workshop para consolidar ICP, alternativas, diferenciacao e proposta de valor.
+- Criar matriz de claims: comprovado, hipotese ou proibido ate evidencia.
+- Refletir decisoes aprovadas em `docs/Analise-Produto-Arquitetura-Concorrencia-Oceano-Azul.md`, `docs/okr.md` e conteudo editorial quando necessario.
+
+#### T2 — UX/UI antes de features de alto custo
+
+- Usar Mobbin para benchmarking de padroes, sem copiar identidade ou assets proprietarios.
+- Usar Product Design para auditar fluxos e prototipar jornadas criticas.
+- Consolidar telas aprovadas no Figma e evoluir Design System/tokens antes de espalhar estilos ad hoc no Next.js.
+- Tratar acessibilidade, loading, empty, error, disabled e responsividade como criterios de aceite.
+
+#### T3 — Implementacao assistida
+
+Para mudancas relevantes, o Codex deve seguir a ordem obrigatoria:
+
+1. problema;
+2. impacto arquitetural;
+3. alternativas;
+4. recomendacao;
+5. riscos;
+6. testes;
+7. seguranca;
+8. impacto multi-tenant;
+9. implementacao.
+
+Figma/Product Design servem de entrada visual; regras de negocio e autorizacao continuam no Spring Boot. Build Web Data Visualization deve apoiar dashboards e visualizacoes quantitativas quando houver metrica definida.
+
+#### T4 — Go-to-market
+
+- Usar B2B Messaging Workshop como fonte para narrativa de homepage, landing pages e sales deck.
+- Usar Creative Production para campanhas e assets dentro da identidade aprovada.
+- Usar Sales para estruturar discovery, demo, business case, proposta e follow-up.
+- Manter Strapi como fonte editorial; Spring Boot permanece dono de leads operacionais, trial, billing e limites.
+
+#### T5 — Analytics e aprendizado continuo
+
+- Instrumentar eventos de produto somente apos definir finalidade, minimizacao, tenant e retencao.
+- Usar Data Analytics para acquisition, activation, engagement, retention, revenue e conversion.
+- Usar Build Web Data Visualization para dashboards do produto e da operacao.
+- Introduzir BuildBetter.ai quando houver volume suficiente de feedback, calls e documentos para apoiar priorizacao baseada em evidencias.
+
+Ferramentas explicitamente fora do conjunto adotado neste momento: **UX Pilot, Zoho CRM e Mailchimp**. A adocao futura depende de necessidade comprovada, custo, privacidade, integracao e sobreposicao com a stack atual.
 
 ## Nichos prioritarios
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -148,6 +148,64 @@ Status atual:
 - **Documentacao:** manter `docs/` como fonte conceitual e atualizar OpenAPI manual ao mudar REST.
 - **Qualidade:** ampliar testes unitarios de dominio e testes de integracao de autenticacao, JPA, JWT e endpoints.
 - **Product/Design/Go-to-Market assistido por IA:** usar o fluxo definido em `docs/ferramentas-ai-product-design-go-to-market.md`, mantendo plugins fora do runtime e submetendo outputs a revisao humana, seguranca, LGPD e governanca do repositorio.
+- **AppSec e criterios de aceite:** aplicar `docs/appsec-criterios-de-aceite.md` em contratos, comunicacoes e regras de negocio, com DoR/DoD e gates de seguranca proporcionais ao risco.
+
+## Trilha transversal — AppSec e criterios de aceite
+
+Referencia operacional: `docs/appsec-criterios-de-aceite.md`.
+
+### A0 — Imediato: baseline de seguranca
+
+- Adotar Codex Security como ferramenta assistiva prioritaria para scans, analise e investigacao de seguranca.
+- Manter CI/GitHub como autoridade de merge e rastreabilidade.
+- Evoluir scanners de dependencias, secrets e SAST/CodeQL quando disponiveis na plataforma.
+- Classificar findings por impacto, explorabilidade, superficie e risco multi-tenant.
+- Findings criticos como cross-tenant leak, auth bypass, segredo valido exposto ou execucao remota exploravel bloqueiam merge/release.
+
+### A1 — Definition of Ready para novas features
+
+Antes de implementar feature relevante, registrar conforme aplicavel:
+
+- problema, ator e valor;
+- criterios de aceite funcionais;
+- contrato tecnico ou declaracao de que nao existe mudanca de contrato;
+- regras de negocio e invariantes;
+- impacto de seguranca, autorizacao e multi-tenant;
+- impacto LGPD/compliance;
+- estados UX relevantes;
+- dependencias externas e riscos.
+
+### A2 — Contratos explicitos
+
+- REST/BFF deve declarar request, response, codigos de erro, autenticacao, autorizacao, tenant e compatibilidade.
+- OpenAPI deve acompanhar mudancas REST.
+- Eventos/mensageria devem possuir nome/versao, produtor/consumidor, retry, idempotencia e minimizacao de dados quando aplicavel.
+- Mudancas breaking exigem estrategia explicita de migracao/versionamento.
+
+### A3 — Comunicacoes confiaveis
+
+- Email, in-app, push e mensagens operacionais devem declarar gatilho, destinatario, canal, conteudo minimo, locale, CTA, retry e comportamento em indisponibilidade.
+- Links devem respeitar autorizacao no destino.
+- Falha de canal secundario nao deve corromper operacao principal salvo regra de negocio explicita.
+- Claims legais/comerciais exigem evidencia e revisao adequada.
+
+### A4 — Regras de negocio testaveis
+
+Cada regra relevante deve explicitar pre-condicoes, atores autorizados, tenant, happy path, bordas, invariantes, erros de dominio, efeitos colaterais, idempotencia/concorrencia, observabilidade e testes.
+
+### A5 — Definition of Done
+
+Uma issue so e concluida quando, conforme aplicavel:
+
+- criterios de aceite passam;
+- testes unitarios e integracao/contrato passam;
+- autorizacao negativa e tentativa cross-tenant foram cobertas para recurso tenant-bound;
+- lint/typecheck/build passam;
+- OpenAPI/docs foram atualizados;
+- findings de seguranca relevantes foram tratados;
+- auditoria/telemetria necessarias existem;
+- nenhum segredo ou dado sensivel indevido aparece no diff;
+- rollback ou estrategia de reversao e conhecida para mudancas de risco.
 
 ## Trilha transversal — Product, Design e Go-to-Market assistidos por plugins
 


### PR DESCRIPTION
Promove para `main` as mudanças documentais já integradas em `develop` pelos PRs #91 e #94.

Inclui:
- governança de uso de plugins e ferramentas assistivas;
- política AppSec e gates SEC-01 a SEC-06;
- Definition of Ready/Done;
- critérios de aceite para contratos, comunicações e regras de negócio;
- atualização de `AGENTS.md`, `docs/roadmap.md` e `docs/appsec-criterios-de-aceite.md`.

Validação: Monorepo CI do head `bccaba8` concluído com sucesso. Não há alteração de runtime nem nova dependência.

Closes #93