### PR TITLE
feat: padronizar erros, correlação e health (#97)

### DIFF
--- a/Backend/java-app1/demo/pom.xml
+++ b/Backend/java-app1/demo/pom.xml
@@ -40,6 +40,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+		<!-- Required by issue #97 so DTO and method constraint failures share the public error contract. -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>

--- a/Backend/java-app1/demo/src/main/java/com/escala/authservice/config/SecurityConfiguration.java
+++ b/Backend/java-app1/demo/src/main/java/com/escala/authservice/config/SecurityConfiguration.java
@@ -35,6 +35,7 @@ public class SecurityConfiguration {
     private final JwtAuthenticationFilter jwtAuthFilter;
     private final TenantIsolationFilter tenantIsolationFilter;
     private final AuthenticationProvider authenticationProvider;
+    private final SecurityErrorHandler securityErrorHandler;
 
     @Value("${app.cors.allowed-origins:http://localhost:3000}")
     private String allowedOrigins;
@@ -86,7 +87,7 @@ public class SecurityConfiguration {
                             .requestMatchers("/api/v1/public/**").permitAll()
                             .requestMatchers("/api/v1/public/content/**").permitAll()
                             .requestMatchers("/api/v1/billing/webhook").permitAll()
-                            .requestMatchers("/actuator/health").permitAll()
+                            .requestMatchers("/actuator/health", "/actuator/health/liveness", "/actuator/health/readiness").permitAll()
                             .requestMatchers("/error").permitAll()
                             .requestMatchers("/actuator/metrics", "/actuator/prometheus").hasAuthority("ADMIN");
 
@@ -96,6 +97,10 @@ public class SecurityConfiguration {
 
                     auth.anyRequest().authenticated();
                 })
+                .exceptionHandling(errors -> errors
+                        .authenticationEntryPoint(securityErrorHandler)
+                        .accessDeniedHandler(securityErrorHandler)
+                )
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
@@ -116,8 +121,8 @@ public class SecurityConfiguration {
                         .toList()
         );
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "If-Match", "X-Requested-With"));
-        configuration.setExposedHeaders(List.of("ETag"));
+        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "If-Match", "X-Requested-With", "X-Correlation-ID"));
+        configuration.setExposedHeaders(List.of("ETag", "X-Correlation-ID"));
         // Spring receives only Authorization: Bearer from the BFF, never a
         // browser session cookie. CORS credentials would add CSRF surface.
         configuration.setAllowCredentials(false);

--- a/Backend/java-app1/demo/src/main/java/com/escala/authservice/config/SecurityErrorHandler.java
+++ b/Backend/java-app1/demo/src/main/java/com/escala/authservice/config/SecurityErrorHandler.java
@@ -1,0 +1,45 @@
+package com.escala.authservice.config;
+
+import com.escala.authservice.controller.ApiError;
+import com.escala.authservice.observability.CorrelationIdFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class SecurityErrorHandler implements AuthenticationEntryPoint, AccessDeniedHandler {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception)
+            throws IOException {
+        write(request, response, HttpServletResponse.SC_UNAUTHORIZED, "AUTHENTICATION_REQUIRED", "Autenticacao necessaria.");
+    }
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       org.springframework.security.access.AccessDeniedException exception) throws IOException {
+        write(request, response, HttpServletResponse.SC_FORBIDDEN, "ACCESS_DENIED", "Acesso negado.");
+    }
+
+    private void write(HttpServletRequest request, HttpServletResponse response, int status, String code, String message)
+            throws IOException {
+        String correlationId = CorrelationIdFilter.from(request);
+        response.setStatus(status);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setHeader(CorrelationIdFilter.HEADER, correlationId);
+        response.setHeader("Cache-Control", "no-store");
+        objectMapper.writeValue(response.getOutputStream(),
+                new ApiError(code, message, status, "ERR-" + UUID.randomUUID(), correlationId));
+    }
+}

--- a/Backend/java-app1/demo/src/main/java/com/escala/authservice/controller/ApiError.java
+++ b/Backend/java-app1/demo/src/main/java/com/escala/authservice/controller/ApiError.java
@@ -1,0 +1,4 @@
+package com.escala.authservice.controller;
+
+public record ApiError(String code, String message, int status, String errorId, String correlationId) {
+}

--- a/Backend/java-app1/demo/src/main/java/com/escala/authservice/controller/ApiExceptionHandler.java
+++ b/Backend/java-app1/demo/src/main/java/com/escala/authservice/controller/ApiExceptionHandler.java
@@ -1,49 +1,81 @@
 package com.escala.authservice.controller;
 
+import com.escala.authservice.observability.CorrelationIdFilter;
 import com.escala.authservice.scheduling.domain.exception.TrocaInvalidaException;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.util.Map;
+import java.util.UUID;
 
 @RestControllerAdvice
 public class ApiExceptionHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApiExceptionHandler.class);
+
     @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<Map<String, String>> handleAccessDenied(AccessDeniedException exception) {
-        return ResponseEntity
-                .status(HttpStatus.FORBIDDEN)
-                .body(Map.of("message", exception.getMessage()));
+    public ResponseEntity<ApiError> handleAccessDenied(AccessDeniedException ex, HttpServletRequest request) {
+        return error(HttpStatus.FORBIDDEN, "ACCESS_DENIED", "Acesso negado.", ex, request, false);
     }
 
     @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
-    public ResponseEntity<Map<String, String>> handleOptimisticLock(ObjectOptimisticLockingFailureException exception) {
-        return ResponseEntity
-                .status(HttpStatus.CONFLICT)
-                .body(Map.of("message", "O registro foi alterado por outro usuario. Atualize a tela e tente novamente."));
+    public ResponseEntity<ApiError> handleOptimisticLock(ObjectOptimisticLockingFailureException ex, HttpServletRequest request) {
+        return error(HttpStatus.CONFLICT, "OPTIMISTIC_LOCK_CONFLICT",
+                "O registro foi alterado por outro usuario. Atualize a tela e tente novamente.", ex, request, false);
     }
 
     @ExceptionHandler(TrocaInvalidaException.class)
-    public ResponseEntity<Map<String, String>> handleTrocaInvalida(TrocaInvalidaException exception) {
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(Map.of("message", exception.getMessage()));
+    public ResponseEntity<ApiError> handleTrocaInvalida(TrocaInvalidaException ex, HttpServletRequest request) {
+        return error(HttpStatus.BAD_REQUEST, "INVALID_SCHEDULE_SWAP", safeMessage(ex), ex, request, false);
+    }
+
+    @ExceptionHandler({MethodArgumentNotValidException.class, ConstraintViolationException.class})
+    public ResponseEntity<ApiError> handleValidation(Exception ex, HttpServletRequest request) {
+        return error(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "Dados informados sao invalidos.", ex, request, false);
     }
 
     @ExceptionHandler(IllegalStateException.class)
-    public ResponseEntity<Map<String, String>> handleIllegalState(IllegalStateException exception) {
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(Map.of("message", exception.getMessage()));
+    public ResponseEntity<ApiError> handleIllegalState(IllegalStateException ex, HttpServletRequest request) {
+        return error(HttpStatus.CONFLICT, "INVALID_STATE", safeMessage(ex), ex, request, false);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException exception) {
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(Map.of("message", exception.getMessage()));
+    public ResponseEntity<ApiError> handleIllegalArgument(IllegalArgumentException ex, HttpServletRequest request) {
+        return error(HttpStatus.BAD_REQUEST, "INVALID_ARGUMENT", safeMessage(ex), ex, request, false);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiError> handleUnexpected(Exception ex, HttpServletRequest request) {
+        return error(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR",
+                "Nao foi possivel concluir a operacao.", ex, request, true);
+    }
+
+    private ResponseEntity<ApiError> error(HttpStatus status, String code, String message, Exception ex,
+                                            HttpServletRequest request, boolean unexpected) {
+        String correlationId = CorrelationIdFilter.from(request);
+        String errorId = "ERR-" + UUID.randomUUID();
+        if (unexpected) {
+            LOGGER.error("event=api_error status={} errorCode={} errorId={} route={} outcome=failure",
+                    status.value(), code, errorId, request.getRequestURI(), ex);
+        } else {
+            LOGGER.warn("event=api_error status={} errorCode={} errorId={} route={} outcome=rejected type={}",
+                    status.value(), code, errorId, request.getRequestURI(), ex.getClass().getSimpleName());
+        }
+        return ResponseEntity.status(status)
+                .header(CorrelationIdFilter.HEADER, correlationId)
+                .body(new ApiError(code, message, status.value(), errorId, correlationId));
+    }
+
+    private String safeMessage(RuntimeException ex) {
+        return ex.getMessage() == null || ex.getMessage().isBlank()
+                ? "A operacao informada e invalida."
+                : ex.getMessage();
     }
 }

--- a/Backend/java-app1/demo/src/main/java/com/escala/authservice/controller/OpenApiController.java
+++ b/Backend/java-app1/demo/src/main/java/com/escala/authservice/controller/OpenApiController.java
@@ -134,6 +134,17 @@ public class OpenApiController {
 
         Map<String, Object> components = new LinkedHashMap<>();
         components.put("securitySchemes", Map.of("bearerAuth", securityScheme));
+        components.put("schemas", Map.of("ApiError", Map.of(
+                "type", "object",
+                "required", List.of("code", "message", "status", "errorId", "correlationId"),
+                "properties", Map.of(
+                        "code", Map.of("type", "string", "example", "VALIDATION_ERROR"),
+                        "message", Map.of("type", "string", "example", "Dados informados sao invalidos."),
+                        "status", Map.of("type", "integer", "example", 400),
+                        "errorId", Map.of("type", "string", "example", "ERR-550e8400-e29b-41d4-a716-446655440000"),
+                        "correlationId", Map.of("type", "string", "example", "550e8400-e29b-41d4-a716-446655440000")
+                )
+        )));
         return components;
     }
 
@@ -355,6 +366,8 @@ public class OpenApiController {
         paths.put("/api/v1/webhooks/chatbot", pathPost(postPublic("IA", "Webhook do Chatbot", "Recebe payloads simulados de mensagens do WhatsApp/Telegram para analise de trocas via IA.", "ChatbotWebhookRequest")));
 
         paths.put("/actuator/health", pathGet(getPublic("Operacional", "Health check", "Retorna o estado de saude do backend para validacao local, Docker e monitoramento.")));
+        paths.put("/actuator/health/liveness", pathGet(getPublic("Operacional", "Liveness", "Confirma que o processo esta vivo sem depender de servicos externos.")));
+        paths.put("/actuator/health/readiness", pathGet(getPublic("Operacional", "Readiness", "Confirma que banco e Redis necessarios para atender trafego estao disponiveis.")));
 
         return paths;
     }
@@ -769,11 +782,22 @@ public class OpenApiController {
         } else {
             responses.put("200", Map.of("description", "Operacao realizada com sucesso."));
         }
-        responses.put("400", Map.of("description", "Requisicao invalida ou regra de dominio violada."));
-        responses.put("401", Map.of("description", "Token ausente, invalido ou expirado."));
-        responses.put("403", Map.of("description", "Usuario autenticado sem permissao para a operacao."));
-        responses.put("404", Map.of("description", "Recurso nao encontrado."));
+        Map<String, Object> errorContent = Map.of("content", Map.of("application/json", Map.of(
+                "schema", Map.of("$ref", "#/components/schemas/ApiError"))));
+        responses.put("400", response("Requisicao invalida ou regra de dominio violada.", errorContent));
+        responses.put("401", response("Token ausente, invalido ou expirado.", errorContent));
+        responses.put("403", response("Usuario autenticado sem permissao para a operacao.", errorContent));
+        responses.put("404", response("Recurso nao encontrado.", errorContent));
+        responses.put("409", response("Conflito com o estado atual do recurso.", errorContent));
+        responses.put("429", response("Limite de requisicoes excedido.", errorContent));
+        responses.put("500", response("Falha interna sem exposicao de detalhes tecnicos.", errorContent));
         return responses;
+    }
+
+    private Map<String, Object> response(String description, Map<String, Object> content) {
+        Map<String, Object> response = new LinkedHashMap<>(content);
+        response.put("description", description);
+        return response;
     }
 
     private String inferResponseName(String summary, String requestName) {

--- a/Backend/java-app1/demo/src/main/java/com/escala/authservice/observability/CorrelationIdFilter.java
+++ b/Backend/java-app1/demo/src/main/java/com/escala/authservice/observability/CorrelationIdFilter.java
@@ -1,0 +1,42 @@
+package com.escala.authservice.observability;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class CorrelationIdFilter extends OncePerRequestFilter {
+    public static final String HEADER = "X-Correlation-ID";
+    public static final String ATTRIBUTE = CorrelationIdFilter.class.getName() + ".correlationId";
+    private static final Pattern SAFE_ID = Pattern.compile("^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$");
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        String supplied = request.getHeader(HEADER);
+        String correlationId = supplied != null && SAFE_ID.matcher(supplied).matches()
+                ? supplied
+                : UUID.randomUUID().toString();
+        request.setAttribute(ATTRIBUTE, correlationId);
+        response.setHeader(HEADER, correlationId);
+        try (MDC.MDCCloseable ignored = MDC.putCloseable("correlationId", correlationId)) {
+            chain.doFilter(request, response);
+        }
+    }
+
+    public static String from(HttpServletRequest request) {
+        Object value = request.getAttribute(ATTRIBUTE);
+        return value instanceof String id ? id : UUID.randomUUID().toString();
+    }
+}

--- a/Backend/java-app1/demo/src/main/resources/application.yml
+++ b/Backend/java-app1/demo/src/main/resources/application.yml
@@ -33,10 +33,22 @@ spring:
       password: ${REDIS_PASSWORD:}
       timeout: 2s
 logging:
+  pattern:
+    console: '{"timestamp":"%d{yyyy-MM-dd''T''HH:mm:ss.SSSXXX}","level":"%level","service":"${spring.application.name}","environment":"${spring.profiles.active:default}","correlationId":"%X{correlationId:-}","logger":"%logger{36}","message":"%replace(%msg){''[\r\n]+'','' ''}"}%n'
   level:
     org.springframework.security.config.annotation.authentication.configuration.InitializeUserDetailsBeanManagerConfigurer: ERROR
 
 management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      show-details: never
+      group:
+        liveness:
+          include: livenessState,ping
+        readiness:
+          include: readinessState,db,redis
   endpoints:
     web:
       exposure:

--- a/Backend/java-app1/demo/src/test/java/com/escala/authservice/config/SecurityConfigurationCorsTest.java
+++ b/Backend/java-app1/demo/src/test/java/com/escala/authservice/config/SecurityConfigurationCorsTest.java
@@ -17,7 +17,8 @@ class SecurityConfigurationCorsTest {
         SecurityConfiguration configuration = new SecurityConfiguration(
                 mock(JwtAuthenticationFilter.class),
                 mock(TenantIsolationFilter.class),
-                mock(AuthenticationProvider.class)
+                mock(AuthenticationProvider.class),
+                mock(SecurityErrorHandler.class)
         );
         ReflectionTestUtils.setField(configuration, "allowedOrigins", "https://app.escala.example");
 
@@ -28,5 +29,6 @@ class SecurityConfigurationCorsTest {
         assertNull(cors.checkOrigin("https://evil.example"));
         assertEquals(Boolean.FALSE, cors.getAllowCredentials());
         assertTrue(cors.getAllowedHeaders().contains("Authorization"));
+        assertTrue(cors.getAllowedHeaders().contains("X-Correlation-ID"));
     }
 }

--- a/Backend/java-app1/demo/src/test/java/com/escala/authservice/controller/ApiExceptionHandlerTest.java
+++ b/Backend/java-app1/demo/src/test/java/com/escala/authservice/controller/ApiExceptionHandlerTest.java
@@ -1,0 +1,43 @@
+package com.escala.authservice.controller;
+
+import com.escala.authservice.observability.CorrelationIdFilter;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApiExceptionHandlerTest {
+    private final ApiExceptionHandler handler = new ApiExceptionHandler();
+
+    @Test
+    void unexpectedErrorsReturnSafeCorrelatedContract() {
+        MockHttpServletRequest request = request("corr-97");
+
+        var response = handler.handleUnexpected(new RuntimeException("jdbc:postgresql://secret internal SQL"), request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().code()).isEqualTo("INTERNAL_ERROR");
+        assertThat(response.getBody().message()).doesNotContain("jdbc", "SQL", "secret");
+        assertThat(response.getBody().correlationId()).isEqualTo("corr-97");
+        assertThat(response.getBody().errorId()).startsWith("ERR-");
+    }
+
+    @Test
+    void accessDeniedDoesNotExposeInternalMessage() {
+        var response = handler.handleAccessDenied(
+                new org.springframework.security.access.AccessDeniedException("tenant 42 does not own resource 9"),
+                request("corr-denied"));
+
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().message()).isEqualTo("Acesso negado.");
+        assertThat(response.getBody().code()).isEqualTo("ACCESS_DENIED");
+    }
+
+    private MockHttpServletRequest request(String correlationId) {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/private");
+        request.setAttribute(CorrelationIdFilter.ATTRIBUTE, correlationId);
+        return request;
+    }
+}

--- a/Backend/java-app1/demo/src/test/java/com/escala/authservice/observability/CorrelationIdFilterTest.java
+++ b/Backend/java-app1/demo/src/test/java/com/escala/authservice/observability/CorrelationIdFilterTest.java
@@ -1,0 +1,34 @@
+package com.escala.authservice.observability;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CorrelationIdFilterTest {
+    private final CorrelationIdFilter filter = new CorrelationIdFilter();
+
+    @Test
+    void propagatesSafeCorrelationId() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/employees");
+        request.addHeader(CorrelationIdFilter.HEADER, "req-123");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, (req, res) ->
+                assertThat(req.getAttribute(CorrelationIdFilter.ATTRIBUTE)).isEqualTo("req-123"));
+
+        assertThat(response.getHeader(CorrelationIdFilter.HEADER)).isEqualTo("req-123");
+    }
+
+    @Test
+    void replacesUnsafeCorrelationId() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/");
+        request.addHeader(CorrelationIdFilter.HEADER, "bad\nvalue");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, (req, res) -> { });
+
+        assertThat(response.getHeader(CorrelationIdFilter.HEADER)).isNotEqualTo("bad\nvalue").isNotBlank();
+    }
+}

--- a/Frontend/web-app3/escala/src/app/[locale]/(PRIVATE)/error.tsx
+++ b/Frontend/web-app3/escala/src/app/[locale]/(PRIVATE)/error.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+export default function PrivateAreaError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <section className="mx-auto mt-16 max-w-lg rounded-lg border p-6 text-center" role="alert">
+      <h2 className="text-xl font-semibold">Esta area nao pode ser carregada</h2>
+      <p className="mt-2 text-muted-foreground">As demais areas continuam disponiveis. Tente novamente ou informe o codigo {error.digest ?? 'indisponivel'} ao suporte.</p>
+      <button className="mt-5 rounded-md bg-primary px-4 py-2 text-primary-foreground" onClick={reset}>Tentar novamente</button>
+    </section>
+  );
+}

--- a/Frontend/web-app3/escala/src/app/api/health/route.ts
+++ b/Frontend/web-app3/escala/src/app/api/health/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+
+export function GET() {
+  return NextResponse.json(
+    { status: 'UP', service: 'escala-frontend' },
+    { headers: { 'Cache-Control': 'no-store' } }
+  );
+}

--- a/Frontend/web-app3/escala/src/app/error.tsx
+++ b/Frontend/web-app3/escala/src/app/error.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  useEffect(() => {
+    console.error('Erro de interface', { digest: error.digest });
+  }, [error]);
+
+  return (
+    <main className="flex min-h-screen items-center justify-center p-6">
+      <section className="max-w-md text-center" role="alert">
+        <h1 className="text-2xl font-semibold">Nao foi possivel carregar esta tela</h1>
+        <p className="mt-3 text-muted-foreground">Tente novamente. Se o problema continuar, informe o codigo {error.digest ?? 'indisponivel'} ao suporte.</p>
+        <button className="mt-6 rounded-md bg-primary px-4 py-2 text-primary-foreground" onClick={reset}>Tentar novamente</button>
+      </section>
+    </main>
+  );
+}

--- a/Frontend/web-app3/escala/src/lib/bff/backend.ts
+++ b/Frontend/web-app3/escala/src/lib/bff/backend.ts
@@ -13,7 +13,44 @@ type BackendRequestOptions = {
   extraHeaders?: Record<string, string>;
 };
 
+type PublicApiError = {
+  code: string;
+  message: string;
+  status: number;
+  errorId: string;
+  correlationId: string;
+};
+
+const CORRELATION_HEADER = 'X-Correlation-ID';
+const SAFE_CORRELATION_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+
+function correlationIdFor(request?: Request) {
+  const supplied = request?.headers.get(CORRELATION_HEADER);
+  return supplied && SAFE_CORRELATION_ID.test(supplied) ? supplied : crypto.randomUUID();
+}
+
+function errorResponse(status: number, code: string, message: string, correlationId: string) {
+  const error: PublicApiError = {
+    code,
+    message,
+    status,
+    errorId: `ERR-${crypto.randomUUID()}`,
+    correlationId,
+  };
+  return NextResponse.json(error, { status, headers: responseHeaders(correlationId) });
+}
+
+function responseHeaders(correlationId: string) {
+  return {
+    'Cache-Control': 'no-store',
+    'X-Content-Type-Options': 'nosniff',
+    'Referrer-Policy': 'strict-origin-when-cross-origin',
+    [CORRELATION_HEADER]: correlationId,
+  };
+}
+
 export async function proxyBackend(path: string, options: BackendRequestOptions = {}) {
+  const correlationId = correlationIdFor(options.request);
   if (options.request) {
     const originError = rejectCrossSiteBffRequest(options.request);
     if (originError) return originError;
@@ -26,6 +63,7 @@ export async function proxyBackend(path: string, options: BackendRequestOptions 
 
   const headers: HeadersInit = {
     Accept: 'application/json',
+    [CORRELATION_HEADER]: correlationId,
   };
 
   const isFormData = options.body instanceof FormData;
@@ -53,6 +91,8 @@ export async function proxyBackend(path: string, options: BackendRequestOptions 
   if (options.extraHeaders) {
     Object.assign(headers, options.extraHeaders);
   }
+  // Callers may add conditional headers, but correlation is owned by this boundary.
+  headers[CORRELATION_HEADER] = correlationId;
 
   if (options.authenticated !== false) {
     let accessToken: string | undefined;
@@ -73,17 +113,7 @@ export async function proxyBackend(path: string, options: BackendRequestOptions 
     }
 
     if (!accessToken) {
-      return NextResponse.json(
-        { message: 'Unauthorized' },
-        {
-          status: 401,
-          headers: {
-            'Cache-Control': 'no-store',
-            'X-Content-Type-Options': 'nosniff',
-            'Referrer-Policy': 'strict-origin-when-cross-origin',
-          },
-        }
-      );
+      return errorResponse(401, 'AUTHENTICATION_REQUIRED', 'Autenticacao necessaria.', correlationId);
     }
     headers.Authorization = `Bearer ${accessToken}`;
   }
@@ -104,45 +134,44 @@ export async function proxyBackend(path: string, options: BackendRequestOptions 
       cache: 'no-store',
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown backend connectivity error';
-    console.warn(`[BFF] ${options.method ?? 'GET'} ${url.toString()}: ${message}`);
-    return NextResponse.json(
-      {
-        message: 'Backend indisponivel no momento',
-        detail: message,
-      },
-      {
-        status: 503,
-        headers: {
-          'Cache-Control': 'no-store',
-          'X-Content-Type-Options': 'nosniff',
-          'Referrer-Policy': 'strict-origin-when-cross-origin',
-        },
-      }
-    );
+    console.warn(JSON.stringify({
+      level: 'warn', service: 'escala-bff', event: 'backend_unavailable', correlationId,
+      method: options.method ?? 'GET', route: path, errorType: error instanceof Error ? error.name : 'UnknownError',
+    }));
+    return errorResponse(503, 'BACKEND_UNAVAILABLE', 'Servico temporariamente indisponivel.', correlationId);
   }
 
   const contentType = response.headers.get('content-type') ?? '';
   if (response.status === 204) {
     return new NextResponse(null, {
       status: 204,
-      headers: {
-        'Cache-Control': 'no-store',
-        'X-Content-Type-Options': 'nosniff',
-        'Referrer-Policy': 'strict-origin-when-cross-origin',
-      },
+      headers: responseHeaders(response.headers.get(CORRELATION_HEADER) ?? correlationId),
     });
   }
 
+  const responseCorrelationId = response.headers.get(CORRELATION_HEADER) ?? correlationId;
   const data = contentType.includes('application/json') ? await response.json() : await response.text();
+
+  if (!response.ok) {
+    const backendError = typeof data === 'object' && data !== null ? data as Partial<PublicApiError> : {};
+    const defaults: Record<number, [string, string]> = {
+      400: ['BAD_REQUEST', 'Requisicao invalida.'], 401: ['AUTHENTICATION_REQUIRED', 'Autenticacao necessaria.'],
+      403: ['ACCESS_DENIED', 'Acesso negado.'], 404: ['RESOURCE_NOT_FOUND', 'Recurso nao encontrado.'],
+      409: ['CONFLICT', 'A operacao conflita com o estado atual.'], 429: ['RATE_LIMITED', 'Muitas requisicoes. Tente novamente em instantes.'],
+    };
+    const [defaultCode, defaultMessage] = defaults[response.status] ?? ['UPSTREAM_ERROR', 'Nao foi possivel concluir a operacao.'];
+    return NextResponse.json({
+      code: backendError.code ?? defaultCode,
+      message: backendError.message ?? defaultMessage,
+      status: response.status,
+      errorId: backendError.errorId ?? `ERR-${crypto.randomUUID()}`,
+      correlationId: responseCorrelationId,
+    } satisfies PublicApiError, { status: response.status, headers: responseHeaders(responseCorrelationId) });
+  }
 
   return NextResponse.json(data, {
     status: response.status,
-    headers: {
-      'Cache-Control': 'no-store',
-      'X-Content-Type-Options': 'nosniff',
-      'Referrer-Policy': 'strict-origin-when-cross-origin',
-    },
+    headers: responseHeaders(responseCorrelationId),
   });
 }
 

--- a/docs/adr-009-error-contract-correlation-health.md
+++ b/docs/adr-009-error-contract-correlation-health.md
@@ -1,0 +1,19 @@
+# ADR-009 — Contrato de erros, correlação e health O0
+
+## Decisão
+
+O boundary `Browser -> Next.js/BFF -> Spring Boot` usa `X-Correlation-ID`. O BFF preserva um identificador sintaticamente seguro recebido ou gera UUID; o Spring valida novamente, propaga na resposta e inclui o valor no MDC. O identificador nunca codifica usuário, email, tenant ou outro dado pessoal e nunca participa de autorização.
+
+Erros públicos usam `{ code, message, status, errorId, correlationId }`. `code` é estável para o frontend; `message` é segura para exibição; `errorId` identifica a ocorrência para suporte. Exceções inesperadas são logadas internamente com stack trace e retornam mensagem genérica. Tokens, cookies, headers de autorização, SQL e payloads sensíveis não são logados.
+
+`spring-boot-starter-validation` é a única dependência adicionada: o starter oficial é necessário para validar DTOs e constraints de método e mapear `MethodArgumentNotValidException`/`ConstraintViolationException` no mesmo contrato público.
+
+## Responsabilidades de health
+
+- `/actuator/health/liveness`: processo Spring vivo, sem dependência externa transitória.
+- `/actuator/health/readiness`: dependências necessárias (`db` e `redis`) prontas para tráfego.
+- `/actuator/health`: resumo compatível com Compose.
+- `/api/health`: processo Next.js/BFF disponível, sem tratar HTML como health.
+- PostgreSQL mantém `pg_isready`; ele não substitui readiness da aplicação.
+
+Detalhes dos componentes de health nunca são expostos. Apenas endpoints de health são públicos; métricas continuam protegidas. O rollback consiste em reverter o commit da issue, mantendo `/actuator/health` compatível.


### PR DESCRIPTION
Closes #97

## Entrega
- adiciona Jakarta Validation ao backend e normaliza erros de validação;
- propaga correlation/request ID entre BFF e Spring;
- padroniza contrato público de erros e respostas do Spring Security;
- adiciona fallbacks `error.tsx` e health do frontend;
- documenta contrato, logs e semântica de readiness/liveness no ADR-009;
- atualiza OpenAPI manual.

## Validação executada
- Backend: 122 testes, 0 falhas;
- Frontend: lint sem erros (warnings preexistentes), typecheck e build;
- Docker Compose: backend/frontend/Strapi/PostgreSQL/Redis iniciados;
- `/actuator/health` UP;
- `/v3/api-docs` e Swagger validados;
- `git diff --check` aprovado.

## Segurança
Correlation ID não é usado como identidade/tenant. Respostas 5xx não expõem stack trace, SQL ou detalhes internos.