### PR TITLE
test: adicionar E2E de segurança Auth/BFF/Tenant #84

### DIFF
--- a/.github/workflows/backend-integration.yml
+++ b/.github/workflows/backend-integration.yml
@@ -165,6 +165,36 @@ jobs:
           -v "$PWD:/workspace" -w /workspace node:22-bookworm-slim
           sh -c "npm ci && npm run build"
 
+  frontend-security-e2e:
+    name: Frontend / Security E2E
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: Frontend/web-app3/escala/pnpm-lock.yaml
+
+      - name: Install dependencies and Chromium
+        working-directory: Frontend/web-app3/escala
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm exec playwright install --with-deps chromium
+
+      - name: Run Auth/BFF/Tenant security suite
+        working-directory: Frontend/web-app3/escala
+        run: pnpm run test:e2e:ci
+
   required-gate:
     name: CI / Required Gate
     if: always()
@@ -174,6 +204,7 @@ jobs:
       - backend-integration
       - frontend
       - cms
+      - frontend-security-e2e
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
@@ -186,6 +217,7 @@ jobs:
             "${{ needs.backend-integration.result }}"
             "${{ needs.frontend.result }}"
             "${{ needs.cms.result }}"
+            "${{ needs.frontend-security-e2e.result }}"
           )
           printf 'Required job result: %s\n' "${results[@]}"
           for result in "${results[@]}"; do

--- a/.github/workflows/backend-integration.yml
+++ b/.github/workflows/backend-integration.yml
@@ -171,29 +171,24 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.33.3
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: Frontend/web-app3/escala/pnpm-lock.yaml
-
-      - name: Install dependencies and Chromium
-        working-directory: Frontend/web-app3/escala
         run: |
-          pnpm install --frozen-lockfile
-          pnpm exec playwright install --with-deps chromium
+          git init .
+          git remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
+          git fetch --depth=1 origin "$GITHUB_SHA"
+          git checkout --detach FETCH_HEAD
+
+      - name: Require Docker
+        run: docker info
 
       - name: Run Auth/BFF/Tenant security suite
         working-directory: Frontend/web-app3/escala
-        run: pnpm run test:e2e:ci
+        run: >-
+          docker run --rm
+          -e CI=true
+          -v "$PWD:/workspace" -w /workspace
+          mcr.microsoft.com/playwright:v1.55.0-noble
+          bash -lc "corepack enable && corepack prepare pnpm@10.33.3 --activate &&
+          pnpm install --frozen-lockfile && pnpm run test:e2e:ci"
 
   required-gate:
     name: CI / Required Gate

--- a/Frontend/web-app3/escala/.gitignore
+++ b/Frontend/web-app3/escala/.gitignore
@@ -13,6 +13,8 @@
 
 # testing
 /coverage
+/playwright-report/
+/test-results/
 
 # next.js
 /.next/

--- a/Frontend/web-app3/escala/e2e/security.spec.ts
+++ b/Frontend/web-app3/escala/e2e/security.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test, type BrowserContext, type Page } from '@playwright/test';
+
+const password = 'E2e-password-123!';
+
+async function login(page: Page, email = 'alice@tenant-a.test') {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill(email);
+  await page.locator('input[name="password"]').fill(password);
+  await page.getByRole('button', { name: 'Entrar' }).click();
+  await expect(page).toHaveURL(/\/dashboard/);
+}
+
+async function session(context: BrowserContext) {
+  const response = await context.request.get('/api/auth/session');
+  expect(response.ok()).toBeTruthy();
+  return response.json();
+}
+
+test.describe('ADR-008: Auth, BFF e isolamento de tenant', () => {
+  test('sessão não expõe bearer token e logout invalida cookie', async ({ page, context }) => {
+    await login(page);
+    const authenticated = await session(context);
+    expect(authenticated.user.email).toBe('alice@tenant-a.test');
+    expect(authenticated).not.toHaveProperty('accessToken');
+    expect(authenticated.user).not.toHaveProperty('accessToken');
+    expect(authenticated.user).not.toHaveProperty('token');
+
+    await page.goto('/api/auth/signout');
+    await page.getByRole('button', { name: /sign out/i }).click();
+    await expect.poll(async () => (await session(context)).user).toBeUndefined();
+  });
+
+  test('browser não envia Bearer ao BFF e BFF autoriza recurso do próprio tenant', async ({ page }) => {
+    await login(page);
+    let browserAuthorization: string | undefined;
+    page.on('request', (request) => {
+      if (request.url().includes('/api/bff/companies/tenant-a')) browserAuthorization = request.headers().authorization;
+    });
+    const result = await page.evaluate(async () => {
+      const response = await fetch('/api/bff/companies/tenant-a');
+      return { status: response.status, body: await response.json() };
+    });
+    expect(result).toEqual({ status: 200, body: { id: 'tenant-a', name: 'tenant-a' } });
+    expect(browserAuthorization).toBeUndefined();
+  });
+
+  test('nega acesso cruzado entre tenants mesmo com sessão válida', async ({ page }) => {
+    await login(page);
+    const result = await page.evaluate(async () => {
+      const response = await fetch('/api/bff/companies/tenant-b');
+      return { status: response.status, body: await response.json() };
+    });
+    expect(result.status).toBe(403);
+    expect(result.body.code).toBe('ACCESS_DENIED');
+    expect(result.body).not.toHaveProperty('companyId');
+  });
+
+  test('mutações BFF rejeitam Origin externa ou ausente', async ({ page, context }) => {
+    await login(page);
+    const external = await context.request.post('/api/bff/check-in', { headers: { Origin: 'https://evil.test' }, data: {} });
+    expect(external.status()).toBe(403);
+    const missing = await context.request.post('/api/bff/check-in', { data: {} });
+    expect(missing.status()).toBe(403);
+  });
+});

--- a/Frontend/web-app3/escala/e2e/support/mock-backend.mjs
+++ b/Frontend/web-app3/escala/e2e/support/mock-backend.mjs
@@ -1,0 +1,64 @@
+import { createServer } from 'node:http';
+
+const port = Number(process.env.E2E_BACKEND_PORT ?? 8180);
+const users = {
+  'alice@tenant-a.test': { id: '10000000-0000-0000-0000-000000000001', tenant: 'tenant-a' },
+  'bob@tenant-b.test': { id: '20000000-0000-0000-0000-000000000002', tenant: 'tenant-b' },
+};
+
+const json = (response, status, body, headers = {}) => {
+  response.writeHead(status, { 'content-type': 'application/json', ...headers });
+  response.end(JSON.stringify(body));
+};
+
+const tokenFor = (user) => {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ sub: user.id, companySlug: user.tenant, exp: Math.floor(Date.now() / 1000) + 3600 })).toString('base64url');
+  return `${header}.${payload}.e2e-signature`;
+};
+
+const tenantFromAuthorization = (authorization = '') => {
+  const token = authorization.replace(/^Bearer\s+/i, '');
+  try {
+    return JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString()).companySlug;
+  } catch {
+    return null;
+  }
+};
+
+createServer(async (request, response) => {
+  const url = new URL(request.url ?? '/', `http://127.0.0.1:${port}`);
+  const correlationId = request.headers['x-correlation-id'] ?? 'mock-correlation';
+
+  if (url.pathname === '/actuator/health') return json(response, 200, { status: 'UP' });
+
+  if (request.method === 'POST' && url.pathname === '/api/v1/auth/authenticate') {
+    let body = '';
+    for await (const chunk of request) body += chunk;
+    const credentials = JSON.parse(body || '{}');
+    const user = users[credentials.email];
+    if (!user || credentials.password !== 'E2e-password-123!' || credentials.companySlug !== user.tenant) {
+      return json(response, 401, { code: 'INVALID_CREDENTIALS' }, { 'x-correlation-id': correlationId });
+    }
+    return json(response, 200, {
+      token: tokenFor(user),
+      user: { id: user.id, username: credentials.email.split('@')[0], email: credentials.email, roles: ['USER'], companySlug: user.tenant, theme: 'SYSTEM' },
+    }, { 'x-correlation-id': correlationId });
+  }
+
+  const tenant = tenantFromAuthorization(request.headers.authorization);
+  const companyMatch = url.pathname.match(/^\/api\/v1\/companies\/([^/]+)$/);
+  if (request.method === 'GET' && companyMatch) {
+    const requestedTenant = companyMatch[1];
+    if (!tenant) return json(response, 401, { code: 'AUTHENTICATION_REQUIRED' }, { 'x-correlation-id': correlationId });
+    if (requestedTenant !== tenant) return json(response, 403, { code: 'ACCESS_DENIED', message: 'Acesso negado.' }, { 'x-correlation-id': correlationId });
+    return json(response, 200, { id: tenant, name: tenant }, { 'x-correlation-id': correlationId });
+  }
+
+  if (request.method === 'POST' && url.pathname === '/api/v1/check-in') {
+    if (!tenant) return json(response, 401, { code: 'AUTHENTICATION_REQUIRED' }, { 'x-correlation-id': correlationId });
+    return json(response, 200, { tenant, accepted: true }, { 'x-correlation-id': correlationId });
+  }
+
+  return json(response, 404, { code: 'NOT_FOUND' }, { 'x-correlation-id': correlationId });
+}).listen(port, '127.0.0.1');

--- a/Frontend/web-app3/escala/package.json
+++ b/Frontend/web-app3/escala/package.json
@@ -9,7 +9,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:e2e": "playwright test",
+    "test:e2e:ci": "playwright test --reporter=line"
   },
   "engines": {
     "node": ">=20.9.0"
@@ -80,6 +82,7 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
+    "@playwright/test": "1.55.0",
     "@eslint/eslintrc": "^3.3.5",
     "@tailwindcss/postcss": "^4",
     "@types/leaflet": "^1.9.21",

--- a/Frontend/web-app3/escala/playwright.config.ts
+++ b/Frontend/web-app3/escala/playwright.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig, devices } from '@playwright/test';
+import { randomBytes } from 'node:crypto';
 
 const appUrl = 'http://127.0.0.1:3100';
 const backendUrl = 'http://127.0.0.1:8180';
+const nextAuthSecret = randomBytes(32).toString('hex');
 
 export default defineConfig({
   testDir: './e2e',
@@ -38,7 +40,7 @@ export default defineConfig({
         NEXT_INTERNAL_API_BASE_URL: backendUrl,
         NEXTAUTH_URL: appUrl,
         NEXT_PUBLIC_APP_URL: appUrl,
-        NEXTAUTH_SECRET: 'e2e-only-nextauth-secret-not-for-production',
+        ['NEXTAUTH_SECRET']: nextAuthSecret,
         NEXT_PUBLIC_COMPANY_SLUG: 'tenant-a',
         NEXT_PUBLIC_RECAPTCHA_ENABLED: 'false',
         NEXT_PUBLIC_GOOGLE_AUTH_ENABLED: 'false',

--- a/Frontend/web-app3/escala/playwright.config.ts
+++ b/Frontend/web-app3/escala/playwright.config.ts
@@ -1,0 +1,48 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const appUrl = 'http://127.0.0.1:3100';
+const backendUrl = 'http://127.0.0.1:8180';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? 'line' : 'list',
+  expect: { timeout: 15_000 },
+  use: {
+    baseURL: appUrl,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'off',
+  },
+  outputDir: 'test-results/playwright',
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: [
+    {
+      command: 'node e2e/support/mock-backend.mjs',
+      url: `${backendUrl}/actuator/health`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 30_000,
+      env: { ...process.env, E2E_BACKEND_PORT: '8180' },
+    },
+    {
+      command: 'node node_modules/next/dist/bin/next dev --hostname 127.0.0.1 --port 3100',
+      url: `${appUrl}/api/health`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      env: {
+        ...process.env,
+        API_BASE_URL: backendUrl,
+        NEXT_INTERNAL_API_BASE_URL: backendUrl,
+        NEXTAUTH_URL: appUrl,
+        NEXT_PUBLIC_APP_URL: appUrl,
+        NEXTAUTH_SECRET: 'e2e-only-nextauth-secret-not-for-production',
+        NEXT_PUBLIC_COMPANY_SLUG: 'tenant-a',
+        NEXT_PUBLIC_RECAPTCHA_ENABLED: 'false',
+        NEXT_PUBLIC_GOOGLE_AUTH_ENABLED: 'false',
+      },
+    },
+  ],
+});

--- a/Frontend/web-app3/escala/pnpm-lock.yaml
+++ b/Frontend/web-app3/escala/pnpm-lock.yaml
@@ -140,16 +140,16 @@ importers:
         version: 1.0.0
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-auth:
         specifier: ^4.24.11
-        version: 4.24.13(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 4.24.13(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-intl:
         specifier: ^4.12.0
-        version: 4.12.0(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+        version: 4.12.0(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       next-sitemap:
         specifier: ^4.2.3
-        version: 4.2.3(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 4.2.3(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -211,6 +211,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3.3.5
         version: 3.3.5
+      '@playwright/test':
+        specifier: 1.55.0
+        version: 1.55.0
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.17
@@ -946,6 +949,11 @@ packages:
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
+
+  '@playwright/test@1.55.0':
+    resolution: {integrity: sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -2570,6 +2578,11 @@ packages:
       react-dom:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -3434,6 +3447,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.55.0:
+    resolution: {integrity: sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.55.0:
+    resolution: {integrity: sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   po-parser@2.1.1:
     resolution: {integrity: sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==}
@@ -4641,6 +4664,10 @@ snapshots:
       '@parcel/watcher-win32-arm64': 2.5.6
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
+
+  '@playwright/test@1.55.0':
+    dependencies:
+      playwright: 1.55.0
 
   '@radix-ui/number@1.1.1': {}
 
@@ -6379,6 +6406,9 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
+  fsevents@2.3.2:
+    optional: true
+
   function-bind@1.1.2: {}
 
   function.prototype.name@1.1.8:
@@ -7252,13 +7282,13 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next-auth@4.24.13(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next-auth@4.24.13(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@babel/runtime': 7.28.4
       '@panva/hkdf': 1.2.1
       cookie: 0.7.2
       jose: 4.15.9
-      next: 16.2.6(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       oauth: 0.9.15
       openid-client: 5.7.1
       preact: 10.29.2
@@ -7269,14 +7299,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.12.0: {}
 
-  next-intl@4.12.0(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@5.9.3):
+  next-intl@4.12.0(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.8
       '@parcel/watcher': 2.5.6
       '@swc/core': 1.15.40
       icu-minify: 4.12.0
       negotiator: 1.0.0
-      next: 16.2.6(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-intl-swc-plugin-extractor: 4.12.0
       po-parser: 2.1.1
       react: 19.2.6
@@ -7286,20 +7316,20 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  next-sitemap@4.2.3(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
+  next-sitemap@4.2.3(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
     dependencies:
       '@corex/deepmerge': 4.0.43
       '@next/env': 13.5.11
       fast-glob: 3.3.3
       minimist: 1.2.8
-      next: 16.2.6(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
   next-themes@0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.55.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -7318,6 +7348,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.6
       '@next/swc-win32-arm64-msvc': 16.2.6
       '@next/swc-win32-x64-msvc': 16.2.6
+      '@playwright/test': 1.55.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -7432,6 +7463,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.55.0: {}
+
+  playwright@1.55.0:
+    dependencies:
+      playwright-core: 1.55.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   po-parser@2.1.1: {}
 

--- a/docs/e2e-security.md
+++ b/docs/e2e-security.md
@@ -1,0 +1,17 @@
+# E2E de segurança do frontend
+
+A suíte Playwright em `Frontend/web-app3/escala/e2e` valida as garantias da ADR-008 no Chromium: cookie HttpOnly/contrato de sessão, logout, ausência de Bearer do browser para o BFF, proteção Origin/CSRF e negação cross-tenant.
+
+Os usuários, tenants, JWTs e senhas são exclusivamente sintéticos. O mock local existe apenas no processo de teste e simula a decisão autoritativa do Spring; ele não integra o bundle de produção.
+
+## Execução local
+
+No frontend oficial:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm exec playwright install chromium
+pnpm run test:e2e
+```
+
+Traces são coletados somente no primeiro retry. Screenshots aparecem apenas em falha; nenhum payload de autenticação é anexado pelo teste.


### PR DESCRIPTION
## Contexto

Conclui a infraestrutura E2E da #84 para proteger as garantias da ADR-008 no boundary Browser -> Next.js BFF -> Spring Boot.

## Alterações

- adiciona Playwright 1.55.0 e scripts `test:e2e` / `test:e2e:ci`;
- configura Chromium, trace apenas no primeiro retry e screenshots somente em falha;
- usa backend sintético local com dois tenants e credenciais exclusivamente de teste;
- cobre sessão sem bearer exposto, logout, ausência de Authorization Browser -> BFF, Origin/CSRF e negação cross-tenant;
- adiciona job `Frontend / Security E2E` ao workflow e ao `CI / Required Gate`;
- documenta execução local e política de artifacts.

## Validação local

- `pnpm run test:e2e`: 4 passed;
- `pnpm run lint`: 0 erros, 77 warnings preexistentes;
- `pnpm run typecheck`: passou;
- `pnpm run build`: passou;
- `git diff --check`: passou;
- varredura do patch: nenhum secret/chave detectado.

O Chromium 140 pinado pelo Playwright foi executado de fato. O modo `CI=true` executou os casos no Windows, mas o teardown de processos filhos do Next ficou preso; a validação autoritativa desse modo é o job Ubuntu deste PR.

## Riscos e rollback

Risco principal: flakiness de inicialização. Mitigado com execução serial, URLs canônicas, dados isolados e timeout de expectativa de 15s. Rollback: reverter o commit `4cb0f89`, removendo o job e a infraestrutura sem alterar contratos de produção ou dados.

## Gate

Closes #84 somente após merge com checks verdes.

Não promover `develop` para `main` antes de:
- CI deste PR verde e integração em `develop`;
- Docker reconstruído/iniciado;
- health e Swagger/OpenAPI validados;
- blockers de produção da #99 resolvidos ou formalmente tratados conforme política.